### PR TITLE
Adds #callback to builder to return Koa request handler

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -115,6 +115,22 @@ export class OrkaBuilder {
     });
   }
 
+  // Return a request handler callback instead of starting the server
+  // Usefull for testing
+  async callback() {
+    const _logger = getLogger('orka');
+    try {
+      while (this.queue.length) {
+        await this.queue.shift()();
+      }
+      const koa = require('./initializers/koa');
+      return koa.callback(this.middlewares);
+    } catch (e) {
+      _logger.error(e);
+      process.exit(1);
+    }
+  }
+
   async start(port: number = this.config.port) {
     const _logger = getLogger('orka');
     try {

--- a/src/initializers/koa/index.ts
+++ b/src/initializers/koa/index.ts
@@ -6,3 +6,9 @@ export default async (port: number, middlewares: Middleware<any>[], callback: ()
   middlewares.forEach(middleware => app.use(middleware));
   return app.listen(port, callback);
 };
+
+export const callback = (middlewares: Middleware<any>[]) => {
+    let app = new Koa();
+    middlewares.forEach(middleware => app.use(middleware));
+    return app.callback();
+};


### PR DESCRIPTION
In `VHS` we use `supertest` for integration testing our api like so:
```
const request = require('supertest');
const app = require('../app');

global.route = request(app.callback());
```

Orka hides the Koa app instance hence we no longer have access to the Koa#callback
This PR adds a `callback` method to the builder which does exactly that. 
