### PR TITLE
Refactoring: Call newrelic by default first. Log an error if config was already used. Log an error if newrelic is used before initialized

### DIFF
--- a/examples/builder-example/app.js
+++ b/examples/builder-example/app.js
@@ -2,7 +2,7 @@ const { builder } = require('../../build');
 
 const staticOptions = { diamorphosis: { configFolder: './examples/simple-example' } };
 
-builder(staticOptions)
+const w = builder(staticOptions)
   .forTypescript()
   .useDefaults()
   .with(config => console.log(`Going to Start env: ${config.nodeEnv}`))
@@ -11,5 +11,11 @@ builder(staticOptions)
     await next();
   })
   .routes('./examples/simple-example/routes.js')
-  .withLogo('./examples/simple-example/logo.txt')
-  .start();
+  .withLogo('./examples/simple-example/logo.txt');
+
+if (!module.parent) {
+  w.start();
+}
+
+w.name = 'builder-example';
+module.exports = w;

--- a/examples/simple-example/app.js
+++ b/examples/simple-example/app.js
@@ -1,7 +1,6 @@
 const { orka } = require('../../build');
-const config = require('./config');
 
-orka({
+const w = orka({
   beforeMiddleware: [
     async (ctx, next) => {
       ctx.body = 'default body';
@@ -11,5 +10,15 @@ orka({
   diamorphosis: { configFolder: './examples/simple-example' },
   routesPath: './examples/simple-example/routes.js',
   logoPath: './examples/simple-example/logo.txt',
-  beforeStart: () => console.log(`Going to start env: ${config.nodeEnv}`)
-}).start();
+  beforeStart: () => {
+    const config = require('./config');
+    console.log(`Going to start env: ${config.nodeEnv}`);
+  }
+});
+
+if (!module.parent) {
+  w.start();
+}
+
+w.name = 'simple-example';
+module.exports = w;

--- a/examples/simple-example/routes.js
+++ b/examples/simple-example/routes.js
@@ -10,5 +10,11 @@ module.exports = {
       }
       throw { status: 401, message: 'Unauthorized' };
     }
+  },
+  prefix: {
+    '/test': async (ctx, next) => {
+      await next();
+      ctx.body = ctx.body + ' changed by prefix';
+    }
   }
 };

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -25,7 +25,7 @@ export default (defaults: Partial<OrkaOptions> = _defaults) => {
   if (cached) {
     getLogger('orka').error(
       new Error(
-        `Config in path ${options.diamorphosis.configPath} was already required.` +
+        `Config in path ${options.diamorphosis.configPath} was already required. ` +
           `Your config might be used before being initialized by orka (diamorphosis).`
       )
     );

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -25,7 +25,8 @@ export default (defaults: Partial<OrkaOptions> = _defaults) => {
   if (cached) {
     getLogger('orka').error(
       new Error(
-        `Config in path ${options.diamorphosis.configPath} was already required. Your config might be used before being initialized by orka (diamorphosis).`
+        `Config in path ${options.diamorphosis.configPath} was already required.` +
+          `Your config might be used before being initialized by orka (diamorphosis).`
       )
     );
   }

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -1,193 +1,47 @@
-import * as path from 'path';
-import * as lodash from 'lodash';
-import { router } from 'fast-koa-router';
-import { Middleware } from 'koa-compose';
-import * as compress from 'koa-compress';
-import * as cors from 'koa2-cors';
-import * as bodyParser from 'koa-bodyparser';
-import diamorphosis from './initializers/diamorphosis';
-import honeybadger from './initializers/honeybadger';
 import newrelic from './initializers/newrelic';
-import rabbitmq from './initializers/rabbitmq';
-import mongodb from './initializers/mongodb';
-import { default as log4js, getLogger } from './initializers/log4js';
-import riviere from './initializers/koa/riviere';
-import addRequestId from './initializers/koa/add-request-id';
-import _defaults from './default-options';
 import { OrkaOptions } from './typings/orka';
-import assert = require('assert');
-import { Server } from 'http';
-import logo from './initializers/logo';
-import kafka from './initializers/kafka';
+import _defaults from './default-options';
+import * as lodash from 'lodash';
+import { getLogger } from './initializers/log4js';
 
-export class OrkaBuilder {
-  options: Partial<OrkaOptions>;
-  config: any;
-  middlewares: Middleware<any>[];
-  errorHandler: any;
-  queue: (() => Promise<void> | void)[];
-  server: Server;
+export default (defaults: Partial<OrkaOptions> = _defaults) => {
+  const options: Partial<OrkaOptions> = lodash.cloneDeep(lodash.defaultsDeep({}, defaults, _defaults));
 
-  constructor(options, config, errorHandler) {
-    this.options = options;
-    this.config = config;
-    this.middlewares = [];
-    this.errorHandler = errorHandler;
-    this.queue = [];
-  }
+  // Always call newrelic
+  newrelic(this.config, defaults);
 
-  use(m: Middleware<any> | Middleware<any>[] = []) {
-    m = lodash.flatten([m]).filter(lodash.identity);
-    m.forEach(__ => this.middlewares.push(__));
-    return this;
-  }
+  const diamorphosis = require('./initializers/diamorphosis').default;
+  const path = require('path');
+  const log4js = require('./initializers/log4js').default;
 
-  useDefaults() {
-    this.use(riviere(this.config));
-    this.use(compress());
-    this.useCors();
-    this.use(addRequestId(this.config));
-    this.use(this.errorHandler(this.config, this.options));
-    this.use(bodyParser());
-    return this;
-  }
-
-  useCors({ credentials = undefined, allowedOrigins = this.config.allowedOrigins } = this.config.cors || {}) {
-    const allowedOrigin = new RegExp('https?://(www\\.)?([^.]+\\.)?(' + allowedOrigins.join(')|(') + ')');
-    return this.use(
-      cors({
-        origin: ctx =>
-          allowedOrigin.test(ctx.request.headers.origin) ? ctx.request.headers.origin : allowedOrigins[0],
-        credentials
-      })
-    );
-  }
-
-  forTypescript(isTypeScript = true) {
-    if (!isTypeScript) {
-      return this;
-    }
-    require('tsconfig-paths/register');
-    require('source-map-support/register');
-    return this;
-  }
-
-  withNewrelic(appName: string = this.options.appName) {
-    this.queue.push(() => newrelic(this.config, { appName }));
-    return this;
-  }
-
-  withRabbitMQ(rabbitOnConnected = () => undefined, appName: string = this.options.appName) {
-    this.queue.push(() => rabbitmq(this.config, { appName, rabbitOnConnected }));
-    return this;
-  }
-
-  withHoneyBadger(o: any = this.options.honeyBadger) {
-    this.queue.push(() => honeybadger(this.config, o));
-    return this;
-  }
-
-  withKafka() {
-    this.queue.push(() => kafka(this.config.kafka));
-    return this;
-  }
-
-  withMongoDB() {
-    this.queue.push(() => mongodb(this.config));
-    return this;
-  }
-
-  with(tasks) {
-    tasks = lodash.flatten([tasks]).filter(lodash.identity);
-    tasks.forEach(task => this.queue.push(() => task(this.config)));
-    return this;
-  }
-
-  withLogo(pathToLogo: string) {
-    this.queue.push(() => logo(this.config, pathToLogo));
-    return this;
-  }
-
-  routes(m: string) {
-    let routes;
-    return this.use((...args) => {
-      routes = require(path.resolve(m));
-      routes = routes.default && Object.keys(routes).length === 1 ? routes.default : routes;
-      return router(routes)(...args);
-    });
-  }
-
-  // Return a request handler callback instead of starting the server
-  // Usefull for testing
-  async callback() {
-    const _logger = getLogger('orka');
-    try {
-      await this.initTasks();
-      const koa = require('./initializers/koa');
-      return koa.callback(this.middlewares);
-    } catch (e) {
-      _logger.error(e);
-      process.exit(1);
-    }
-  }
-
-  async initTasks() {
-    while (this.queue.length) {
-      await this.queue.shift()();
-    }
-    return this;
-  }
-
-  async start(port: number = this.config.port) {
-    const _logger = getLogger('orka');
-    try {
-      _logger.info(
-        `Initializing orka processing ${this.queue.length} tasks and ${this.middlewares.length} middlewares…`
-      );
-      await this.initTasks();
-      const koa = await import('./initializers/koa');
-      this.server = await koa.default(port, this.middlewares, (logger = _logger) => {
-        logger.info(`Server listening to http://localhost:${port}/`);
-        logger.info(`Server environment: ${this.config.nodeEnv}`);
-      });
-    } catch (e) {
-      _logger.error(e);
-      process.exit(1);
-    }
-    return this;
-  }
-
-  async stop() {
-    const _logger = getLogger('orka');
-    assert(this.server, 'Application is not started');
-    _logger.info('Shutting down server');
-    this.server.close();
-  }
-}
-
-const builder = (defaults: Partial<OrkaOptions> = _defaults) => {
-  const options: Partial<OrkaOptions> = lodash.cloneDeep(defaults);
-  // Always initialize diamorphosis.
+  // Always initialize diamorphosis
   if (!options.diamorphosis.configPath) {
     options.diamorphosis.configPath = path.resolve(options.diamorphosis.configFolder + '/config');
   }
   if (!options.diamorphosis.envFolder) {
     options.diamorphosis.envFolder = path.resolve(options.diamorphosis.configFolder + '/env');
   }
-  let config = require(`${options.diamorphosis.configPath}`);
-  //module.exports vs export default
+  const cached = require.cache[require.resolve(options.diamorphosis.configPath)];
+  if (cached) {
+    getLogger('orka').error(
+      new Error(
+        `Config in path ${options.diamorphosis.configPath} was already required. Your config might be used before being initialized by orka (diamorphosis).`
+      )
+    );
+  }
+  let config = require(options.diamorphosis.configPath);
+  // module.exports vs export default
   config = config.default && Object.keys(config).length === 1 ? config.default : config;
   diamorphosis(config, options);
 
   options.appName = options.appName || (config.app && config.app.name);
 
-  // always use logger
+  // Always use logger
   log4js(config);
 
   // errorHandler needs to be called after log4js initialization for logger to work as expected.
   const errorHandler = require('./initializers/koa/error-handler').default;
 
+  const OrkaBuilder = require('./orka-builder').default;
   return new OrkaBuilder(options, config, errorHandler);
 };
-
-export default builder;

--- a/src/initializers/diamorphosis.ts
+++ b/src/initializers/diamorphosis.ts
@@ -5,7 +5,6 @@ export default (config, orkaOptions: Partial<OrkaOptions>) => {
   config.nodeEnv = config.nodeEnv || 'development';
   config.honeybadgerApiKey = config.honeybadgerApiKey || '';
   config.honeybadgerEnvironment = config.honeybadgerEnvironment || config.nodeEnv;
-  config.newRelicLicenseKey = '';
   config.printLogo = config.printLogo || true;
   config.log = {
     pattern: '%[[%d] [%p] %c%] %m',

--- a/src/initializers/newrelic/index.ts
+++ b/src/initializers/newrelic/index.ts
@@ -1,13 +1,19 @@
 import { OrkaOptions } from '../../typings/orka';
 import requireInjected from '../../require-injected';
+import { getLogger } from '../log4js';
 
 let newrelic;
 export default async (config, orkaOptions: Partial<OrkaOptions>) => {
   process.env.NEW_RELIC_HOME = __dirname;
-  if (config.newRelicLicenseKey) {
+  if (process.env.NEW_RELIC_LICENSE_KEY) {
     process.env.NEW_RELIC_APP_NAME = `${orkaOptions.appName} ${config.nodeEnv}`;
     newrelic = requireInjected('newrelic');
   }
 };
 
-export const getNewRelic = () => newrelic;
+export const getNewRelic = () => {
+  if (!newrelic) {
+    getLogger('orka.initializers.newrelic').error(new Error('Newrelic required before initialized.'));
+  }
+  return newrelic;
+};

--- a/src/orka-builder.ts
+++ b/src/orka-builder.ts
@@ -83,7 +83,7 @@ export default class OrkaBuilder {
   withNewrelic() {
     const logger = getLogger('orka');
     logger.warn(
-      `withNewrelic is deprecated and will be removed.` +
+      `withNewrelic is deprecated and will be removed. ` +
         `Newrelic will be initialized by default if NEW_RELIC_LICENCE_KEY is found in env`
     );
     return this;

--- a/src/orka-builder.ts
+++ b/src/orka-builder.ts
@@ -83,8 +83,8 @@ export default class OrkaBuilder {
   withNewrelic() {
     const logger = getLogger('orka');
     logger.warn(
-      `withNewrelic is deprecated and will be removed. 
-Newrelic will be initialized by default if NEW_RELIC_LICENCE_KEY is found in env`
+      `withNewrelic is deprecated and will be removed.` +
+        `Newrelic will be initialized by default if NEW_RELIC_LICENCE_KEY is found in env`
     );
     return this;
   }

--- a/src/orka-builder.ts
+++ b/src/orka-builder.ts
@@ -1,0 +1,168 @@
+import * as path from 'path';
+import * as lodash from 'lodash';
+import { router } from 'fast-koa-router';
+import { Middleware } from 'koa';
+import * as compress from 'koa-compress';
+import * as cors from 'koa2-cors';
+import * as bodyParser from 'koa-bodyparser';
+import honeybadger from './initializers/honeybadger';
+import rabbitmq from './initializers/rabbitmq';
+import mongodb from './initializers/mongodb';
+import { getLogger } from './initializers/log4js';
+import riviere from './initializers/koa/riviere';
+import addRequestId from './initializers/koa/add-request-id';
+import _defaults from './default-options';
+import { OrkaOptions } from './typings/orka';
+import assert = require('assert');
+import { Server } from 'http';
+import logo from './initializers/logo';
+import kafka from './initializers/kafka';
+
+export default class OrkaBuilder {
+  options: Partial<OrkaOptions>;
+  config: any;
+  middlewares: Middleware<any>[];
+  errorHandler: any;
+  queue: (() => Promise<void> | void)[];
+  server: Server;
+
+  constructor(options, config, errorHandler) {
+    this.options = options;
+    this.config = config;
+    this.middlewares = [];
+    this.errorHandler = errorHandler;
+    this.queue = [];
+  }
+
+  use(m: Middleware<any> | Middleware<any>[] = []) {
+    m = lodash.flatten([m]).filter(lodash.identity);
+    m.forEach(__ => this.middlewares.push(__));
+    return this;
+  }
+
+  useDefaults() {
+    this.use(riviere(this.config));
+    this.use(compress());
+    this.useCors();
+    this.use(addRequestId(this.config));
+    this.use(this.errorHandler(this.config, this.options));
+    this.use(bodyParser());
+    return this;
+  }
+
+  useCors({ credentials = undefined, allowedOrigins = this.config.allowedOrigins } = this.config.cors || {}) {
+    const allowedOrigin = new RegExp('https?://(www\\.)?([^.]+\\.)?(' + allowedOrigins.join(')|(') + ')');
+    return this.use(
+      cors({
+        origin: ctx =>
+          allowedOrigin.test(ctx.request.headers.origin) ? ctx.request.headers.origin : allowedOrigins[0],
+        credentials
+      })
+    );
+  }
+
+  forTypescript(isTypeScript = true) {
+    if (!isTypeScript) {
+      return this;
+    }
+    require('tsconfig-paths/register');
+    require('source-map-support/register');
+    return this;
+  }
+
+  withRabbitMQ(rabbitOnConnected = () => undefined, appName: string = this.options.appName) {
+    this.queue.push(() => rabbitmq(this.config, { appName, rabbitOnConnected }));
+    return this;
+  }
+
+  withHoneyBadger(o: any = this.options.honeyBadger) {
+    this.queue.push(() => honeybadger(this.config, o));
+    return this;
+  }
+
+  withNewrelic() {
+    const logger = getLogger('orka');
+    logger.warn(
+      `withNewrelic is deprecated and will be removed. 
+Newrelic will be initialized by default if NEW_RELIC_LICENCE_KEY is found in env`
+    );
+    return this;
+  }
+
+  withKafka() {
+    this.queue.push(() => kafka(this.config.kafka));
+    return this;
+  }
+
+  withMongoDB() {
+    this.queue.push(() => mongodb(this.config));
+    return this;
+  }
+
+  with(tasks) {
+    tasks = lodash.flatten([tasks]).filter(lodash.identity);
+    tasks.forEach(task => this.queue.push(() => task(this.config)));
+    return this;
+  }
+
+  withLogo(pathToLogo: string) {
+    this.queue.push(() => logo(this.config, pathToLogo));
+    return this;
+  }
+
+  routes(m: string) {
+    let routes;
+    return this.use((...args) => {
+      routes = require(path.resolve(m));
+      routes = routes.default && Object.keys(routes).length === 1 ? routes.default : routes;
+      return router(routes)(...args);
+    });
+  }
+
+  // Return a request handler callback instead of starting the server
+  // Usefull for testing
+  async callback() {
+    const _logger = getLogger('orka');
+    try {
+      await this.initTasks();
+      const koa = require('./initializers/koa');
+      return koa.callback(this.middlewares);
+    } catch (e) {
+      _logger.error(e);
+      process.exit(1);
+    }
+  }
+
+  async initTasks() {
+    while (this.queue.length) {
+      await this.queue.shift()();
+    }
+    return this;
+  }
+
+  async start(port: number = this.config.port) {
+    const _logger = getLogger('orka');
+    try {
+      _logger.info(
+        `Initializing orka processing ${this.queue.length} tasks and ${this.middlewares.length} middlewares…`
+      );
+      await this.initTasks();
+      const koa = await import('./initializers/koa');
+      this.server = await koa.default(port, this.middlewares, (logger = _logger) => {
+        logger.info(`Server listening to http://localhost:${port}/`);
+        logger.info(`Server environment: ${this.config.nodeEnv}`);
+      });
+    } catch (e) {
+      _logger.error(e);
+      process.exit(1);
+    }
+    return this;
+  }
+
+  async stop() {
+    const _logger = getLogger('orka');
+    assert(this.server, 'Application is not started');
+    _logger.info('Shutting down server');
+    this.server.close();
+  }
+}

--- a/src/orka.ts
+++ b/src/orka.ts
@@ -10,7 +10,6 @@ const fromOptions = (options: Partial<OrkaOptions>) => {
     .useDefaults()
     .use(options.afterMiddleware)
     .withLogo(options.logoPath)
-    .withNewrelic()
     .withRabbitMQ(options.rabbitOnConnected)
     .withHoneyBadger()
     .withKafka()

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -9,13 +9,12 @@
     "declaration": true,
     "suppressImplicitAnyIndexErrors": true,
     "outDir": "../build",
+    "noUnusedLocals": true,
     "sourceMap": true,
     "baseUrl": ".",
     "paths": {
       "orka/*": ["./*"]
     }
   },
-  "filesGlob": [
-    "./*.ts"
-  ]
+  "filesGlob": ["./*.ts"]
 }

--- a/test/examples/examples.test.ts
+++ b/test/examples/examples.test.ts
@@ -1,0 +1,31 @@
+import 'should';
+import * as supertest from 'supertest';
+const ws = [require('../../examples/simple-example/app'), require('../../examples/builder-example/app')];
+
+describe('examples', function() {
+  ws.forEach(function(server) {
+    describe('Example:' + server.name, function() {
+      after(function() {
+        server.stop();
+      });
+
+      before(function() {
+        server.start();
+      });
+
+      it('/test returns ok', async function() {
+        const { text } = await (supertest('localhost:3000') as any).get('/test').expect(200);
+        text.should.eql('ok changed by prefix');
+      });
+
+      it('/testPolicy returns 401', async function() {
+        await (supertest('localhost:3000') as any).get('/testPolicy').expect(401);
+      });
+
+      it('/testPolicy returns 200', async function() {
+        const { text } = await (supertest('localhost:3000') as any).get('/testPolicy?secret_key=success').expect(200);
+        text.should.eql('ok changed by prefix');
+      });
+    });
+  });
+});

--- a/tslint.json
+++ b/tslint.json
@@ -4,28 +4,14 @@
     "curly": false,
     "eofline": true,
     "forin": true,
-    "indent": [
-      false
-    ],
+    "indent": [false],
     "label-position": true,
-    // "label-undefined": true,
-    "max-line-length": [
-      true,
-      140
-    ],
+    "max-line-length": [true, 140],
     "no-arg": true,
     "no-bitwise": true,
-    "no-console": [
-      true,
-      "debug",
-      "info",
-      "time",
-      "timeEnd",
-      "trace"
-    ],
+    "no-console": [true, "debug", "info", "time", "timeEnd", "trace"],
     "no-construct": true,
     "no-debugger": true,
-    // "no-duplicate-key": true,
     "no-duplicate-variable": true,
     "no-empty": true,
     "no-eval": true,
@@ -33,34 +19,12 @@
     "no-switch-case-fall-through": true,
     "no-trailing-whitespace": true,
     "no-unused-expression": true,
-    // "no-unused-variable": true,
-    // "no-unreachable": true,
-    "no-use-before-declare": true,
-    "one-line": [
-      true,
-      "check-open-brace",
-      "check-catch",
-      "check-else",
-      "check-whitespace"
-    ],
-    "quotemark": [
-      true,
-      "single"
-    ],
+    "one-line": [true, "check-open-brace", "check-catch", "check-else", "check-whitespace"],
+    "quotemark": [true, "single"],
     "radix": true,
     "semicolon": true,
-    "triple-equals": [
-      true,
-      "allow-null-check"
-    ],
+    "triple-equals": [true, "allow-null-check"],
     "variable-name": false,
-    "whitespace": [
-      true,
-      "check-branch",
-      "check-decl",
-      "check-operator",
-      "check-separator",
-      "check-type"
-    ]
+    "whitespace": [true, "check-branch", "check-decl", "check-operator", "check-separator", "check-type"]
   }
 }


### PR DESCRIPTION
refactoring
Should fix #64 

Will add some e2e tests for the examples before merging.