### PR TITLE
Don't log when connection is closing to prevent log spamming

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@workablehr/orka",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workablehr/orka",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "",
   "main": "build/index.js",
   "scripts": {

--- a/src/initializers/kafka/kafka.ts
+++ b/src/initializers/kafka/kafka.ts
@@ -41,6 +41,7 @@ export default class Kafka {
         'socket.keepalive.enable': true,
         'api.version.request': true,
         'socket.blocking.max.ms': 100,
+        'log.connection.close': false,
         ...this.authOptions
       },
       tconf: {
@@ -61,6 +62,7 @@ export default class Kafka {
         'socket.keepalive.enable': true,
         'api.version.request': true,
         'queue.buffering.max.ms': 1000,
+        'log.connection.close': false,
         ...this.authOptions
       },
       tconf: {


### PR DESCRIPTION
## Summary
Prevents producer/consumer when connection is closed due to inactivity. When a message needs to be sent the producer reconnects to kafka.

[Sample log](https://app.honeybadger.io/projects/60295/faults/54500274?at=2019-09-18T07:00:00+03:00#notice-history)

[Kafka Options](https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md)