### PR TITLE
add default routes

### DIFF
--- a/examples/simple-example/routes.js
+++ b/examples/simple-example/routes.js
@@ -2,6 +2,7 @@ const { getLogger } = require('../../build');
 
 module.exports = {
   get: {
+    '/health': async ctx => (ctx.status = 500),
     '/test': async (ctx, next) => (ctx.body = 'ok'),
     '/testPolicy': async (ctx, next) => (ctx.body = 'ok'),
     '/log': async (ctx, next) => {

--- a/src/initializers/koa/routes.ts
+++ b/src/initializers/koa/routes.ts
@@ -1,0 +1,23 @@
+import * as os from 'os';
+
+export default {
+  get: {
+    '/health': async ctx => (ctx.status = 200),
+    '/ping': async ctx => (ctx.status = 200),
+    '/status': async ctx => {
+      const mem = process.memoryUsage();
+      const m = 1024 * 1024;
+
+      ctx.body = {
+        rss: (mem.rss / m).toFixed(2) + 'M',
+        heapTotal: (mem.heapTotal / m).toFixed(2) + 'M',
+        heapUsed: (mem.heapUsed / m).toFixed(2) + 'M',
+        loadAvg: os.loadavg()
+      };
+
+      if (ctx.request.query.refresh) {
+        ctx.set('Refresh', ctx.request.query.refresh);
+      }
+    }
+  }
+};

--- a/src/orka-builder.ts
+++ b/src/orka-builder.ts
@@ -20,6 +20,7 @@ import { Server } from 'http';
 import logo from './initializers/logo';
 import kafka from './initializers/kafka';
 import * as Koa from 'koa';
+import defaultRoutes from './initializers/koa/routes';
 
 export default class OrkaBuilder {
   options: Partial<OrkaOptions>;
@@ -146,6 +147,7 @@ export default class OrkaBuilder {
     return this.use(() => {
       let routes = require(path.resolve(m));
       routes = routes.default && Object.keys(routes).length === 1 ? routes.default : routes;
+      routes = lodash.merge({}, defaultRoutes, routes);
       return router(routes);
     });
   }

--- a/test/examples/examples.test.ts
+++ b/test/examples/examples.test.ts
@@ -35,6 +35,15 @@ describe('examples', function() {
         server.start();
       });
 
+      it('/health returns ok (overrides default)', async function() {
+        await (supertest('localhost:3000') as any).get('/health').expect(500);
+      });
+
+      it('/status returns body (no default provided)', async function() {
+        const { body } = await (supertest('localhost:3000') as any).get('/status').expect(200);
+        Object.keys(body).should.eql(['rss', 'heapTotal', 'heapUsed', 'loadAvg']);
+      });
+
       it('/test returns ok', async function() {
         const { text } = await (supertest('localhost:3000') as any).get('/test').expect(200);
         text.should.eql('ok changed by prefix');


### PR DESCRIPTION
Solves https://github.com/Workable/orka/issues/31

- A routes file has been added including health and stataus (more can be added if needed)
- The default routes can be overridden if the implementation for those routes is provided