### PR TITLE
add validate params middleware

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -63,6 +63,14 @@
     {
       "type": "node",
       "request": "launch",
+      "name": "Validation example",
+      "program": "${workspaceFolder}/examples/validation-example/app.js",
+      "outFiles": ["${workspaceFolder}/**/*.js"],
+      "preLaunchTask": "build"
+    },
+    {
+      "type": "node",
+      "request": "launch",
       "name": "Mocha Tests",
       "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
       "args": [

--- a/examples/validation-example/app.js
+++ b/examples/validation-example/app.js
@@ -1,0 +1,17 @@
+const { orka } = require('../../build');
+
+const w = orka({
+  diamorphosis: { configFolder: './examples/simple-example' },
+  routesPath: './examples/validation-example/routes.js',
+  logoPath: './examples/simple-example/logo.txt',
+  beforeStart: () => {
+    const config = require('../simple-example/config');
+    console.log(`Going to start env: ${config.nodeEnv}`);
+  }
+});
+
+if (!module.parent) {
+  w.start();
+}
+
+module.exports = w;

--- a/examples/validation-example/routes.js
+++ b/examples/validation-example/routes.js
@@ -1,0 +1,18 @@
+const { validateQueryString, validateBody } = require('../../build');
+const Joi = require('@hapi/joi');
+
+const schema = Joi.object().keys({
+  keyString: Joi.string(),
+  keyNumber: Joi.number(),
+  keyBoolean: Joi.boolean(),
+  keyStringArray: Joi.array().items(Joi.string())
+});
+
+module.exports = {
+  get: {
+    '/testGet': [validateQueryString(schema), async (ctx, next) => (ctx.body = ctx.request.body)]
+  },
+  post: {
+    '/testPost': [validateBody(schema), async (ctx, next) => (ctx.body = ctx.request.body)]
+  }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -195,6 +195,49 @@
       "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-1.0.4.tgz",
       "integrity": "sha512-VccZDcOql77obTnFh0TbNED/6ZbbmHDf8UMNnzO1d5g9V0Htfm4k5cllY8P1tJsRKC3zWYGRLaViiupcgVjBoQ=="
     },
+    "@hapi/address": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-4.0.0.tgz",
+      "integrity": "sha512-GDDpkCdSUfkQCznmWUHh9dDN85BWf/V8TFKQ2JLuHdGB4Yy3YTEGBzZxoBNxfNBEvreSR/o+ZxBBSNNEVzY+lQ==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "@hapi/formula": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-2.0.0.tgz",
+      "integrity": "sha512-V87P8fv7PI0LH7LiVi8Lkf3x+KCO7pQozXRssAHNXXL9L1K+uyu4XypLXwxqVDKgyQai6qj3/KteNlrqDx4W5A=="
+    },
+    "@hapi/hoek": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.0.3.tgz",
+      "integrity": "sha512-jKtjLLDiH95b002sJVc5c74PE6KKYftuyVdVmsuYId5stTaWcRFqE+5ukZI4gDUKjGn8wv2C3zPn3/nyjEI7gg=="
+    },
+    "@hapi/joi": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-17.1.0.tgz",
+      "integrity": "sha512-ob67RcPlwRWxBzLCnWvcwx5qbwf88I3ykD7gcJLWOTRfLLgosK7r6aeChz4thA3XRvuBfI0KB1tPVl2EQFlPXw==",
+      "requires": {
+        "@hapi/address": "^4.0.0",
+        "@hapi/formula": "^2.0.0",
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/pinpoint": "^2.0.0",
+        "@hapi/topo": "^5.0.0"
+      }
+    },
+    "@hapi/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-vzXR5MY7n4XeIvLpfl3HtE3coZYO4raKXW766R6DZw/6aLqR26iuZ109K7a0NtF2Db0jxqh7xz2AxkUwpUFybw=="
+    },
+    "@hapi/topo": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
+      "integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
     "@log4js-node/log4js-api": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@log4js-node/log4js-api/-/log4js-api-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   },
   "dependencies": {
     "@google-cloud/debug-agent": "^4.2.1",
+    "@hapi/joi": "^17.1.0",
     "@workablehr/riviere": "^1.6.0",
     "codependency": "^2.1.0",
     "diamorphosis": "^0.8.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,3 +10,4 @@ export { getKafka } from './initializers/kafka';
 export { getRabbit } from './initializers/rabbitmq';
 export { getRedis, createRedisConnection } from './initializers/redis';
 export { middlewares };
+export { validateBody, validateQueryString } from './initializers/koa/validate-params';

--- a/src/initializers/koa/errors/custom-error.ts
+++ b/src/initializers/koa/errors/custom-error.ts
@@ -1,0 +1,7 @@
+export class CustomError extends Error {
+  constructor(msg?: string) {
+    super(msg);
+    this.name = this.constructor.name;
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/src/initializers/koa/errors/validation-error.ts
+++ b/src/initializers/koa/errors/validation-error.ts
@@ -1,0 +1,9 @@
+import { CustomError } from './custom-error';
+
+export class ValidationError extends CustomError {
+  public exposedMsg: object;
+  constructor(msg: object, public status: number, public expose?: boolean) {
+    super(JSON.stringify(msg));
+    this.exposedMsg = msg;
+  }
+}

--- a/src/initializers/koa/validate-params.ts
+++ b/src/initializers/koa/validate-params.ts
@@ -1,0 +1,34 @@
+import * as Joi from '@hapi/joi';
+import { ValidationError } from './errors/validation-error';
+import * as Koa from 'koa';
+
+function validate(body: any, schema: Joi.ObjectSchema) {
+  const result = schema.validate(body, { abortEarly: false });
+  const error = result && result.error;
+  if (error) {
+    const msg =
+      error.details &&
+      error.details.reduce(
+        (agg: any, { context: { key = '' } = {}, message = '' }: any) => ({ ...agg, [key]: message }),
+        {}
+      );
+    throw new ValidationError(msg || { error: error.message }, 400, true);
+  }
+  return result;
+}
+
+export function validateBody(schema: Joi.ObjectSchema) {
+  return async (ctx: Koa.Context, next: any) => {
+    const result = validate(ctx.request.body, schema);
+    ctx.request.body = result.value;
+    await next();
+  };
+}
+
+export function validateQueryString(schema: Joi.ObjectSchema) {
+  return async (ctx: Koa.Context, next: any) => {
+    // TODO: add the result of validate inside ctx in order to use it down the line
+    validate(ctx.query, schema);
+    await next();
+  };
+}

--- a/test/examples/validation-examples.test.ts
+++ b/test/examples/validation-examples.test.ts
@@ -1,0 +1,50 @@
+import 'should';
+import * as supertest from 'supertest';
+
+describe('Validation examples', () => {
+  let server;
+  after(async () => {
+    if (server) await server.stop();
+  });
+
+  before(async () => {
+    const serverPath = '../../examples/validation-example/app';
+    delete require.cache[require.resolve(serverPath)];
+    server = require(serverPath);
+    await server.start();
+  });
+
+  it('/testGet returns 200', async () => {
+    const { text } = await supertest('localhost:3000')
+      .get('/testGet?keyNumber=2')
+      .expect(200);
+
+    text.should.eql(JSON.stringify({}));
+  });
+
+  it('/testGet returns 400', async () => {
+    const { text } = await supertest('localhost:3000')
+      .get('/testGet?keyNumber=somestring')
+      .expect(400);
+
+    text.should.equal(JSON.stringify({ keyNumber: '"keyNumber" must be a number' }));
+  });
+
+  it('/testPost returns 200', async () => {
+    const { text } = await supertest('localhost:3000')
+      .post('/testPost')
+      .send({ keyNumber: 2 })
+      .expect(200);
+
+    text.should.eql(JSON.stringify({ keyNumber: 2 }));
+  });
+
+  it('/testPost returns 400', async () => {
+    const { text } = await supertest('localhost:3000')
+      .post('/testPost')
+      .send({ keyNumber: 'somestring' })
+      .expect(400);
+
+    text.should.equal(JSON.stringify({ keyNumber: '"keyNumber" must be a number' }));
+  });
+});

--- a/test/initializers/koa/errors/custom-error.test.ts
+++ b/test/initializers/koa/errors/custom-error.test.ts
@@ -1,0 +1,24 @@
+import 'should';
+import * as sinon from 'sinon';
+import { CustomError } from '../../../../src/initializers/koa/errors/custom-error';
+
+const sandbox = sinon.createSandbox();
+
+describe('custom-error', function() {
+  before(function() {
+    sandbox.restore();
+  });
+
+  afterEach(function() {
+    sandbox.restore();
+  });
+
+  it('tests custom error handler', async function() {
+    const errorSpy = sandbox.spy(Error, 'captureStackTrace');
+    const error = new CustomError('This is a test');
+    error.message.should.equal('This is a test');
+    error.name.should.equal('CustomError');
+    error.stack.should.be.ok();
+    errorSpy.calledOnce.should.equal(true);
+  });
+});

--- a/test/initializers/koa/errors/validation-error.test.ts
+++ b/test/initializers/koa/errors/validation-error.test.ts
@@ -1,0 +1,26 @@
+import 'should';
+import * as sinon from 'sinon';
+import { ValidationError } from '../../../../src/initializers/koa/errors/validation-error';
+
+const sandbox = sinon.createSandbox();
+
+describe('validation-error', function() {
+  before(function() {
+    sandbox.restore();
+  });
+
+  afterEach(function() {
+    sandbox.restore();
+  });
+
+  it('tests validation error, exposed true', async function() {
+    const errorSpy = sandbox.spy(Error, 'captureStackTrace');
+    const error = new ValidationError({ message: 'This is a test' }, 500);
+    error.message.should.equal(JSON.stringify({ message: 'This is a test' }));
+    error.name.should.equal('ValidationError');
+    error.stack.should.be.ok();
+    error.status.should.be.equal(500);
+    error.exposedMsg.should.be.eql({ message: 'This is a test' });
+    errorSpy.calledOnce.should.equal(true);
+  });
+});

--- a/test/initializers/koa/validate-params.test.ts
+++ b/test/initializers/koa/validate-params.test.ts
@@ -1,0 +1,80 @@
+import 'should';
+import * as sinon from 'sinon';
+import * as Joi from '@hapi/joi';
+import { validateBody, validateQueryString } from '../../../src/initializers/koa/validate-params';
+
+const sandbox = sinon.createSandbox();
+
+const schema = Joi.object().keys({
+  keyString: Joi.string(),
+  keyNumber: Joi.number(),
+  keyBoolean: Joi.boolean(),
+  keyStringArray: Joi.array().items(Joi.string())
+});
+
+describe('validate-params', function() {
+  before(function() {
+    sandbox.restore();
+  });
+
+  afterEach(function() {
+    sandbox.restore();
+  });
+
+  it('tests validate body', async function() {
+    const next = sandbox.stub();
+    const ctx = {
+      request: {
+        body: {
+          keyString: 'somestring',
+          keyNumber: '2',
+          keyBoolean: 'true',
+          keyStringArray: ['a', 'b']
+        }
+      }
+    } as any;
+
+    await validateBody(schema)(ctx, next);
+
+    next.calledOnce.should.be.equal(true);
+    ctx.request.body.should.eql({
+      keyString: 'somestring',
+      keyNumber: 2,
+      keyBoolean: true,
+      keyStringArray: ['a', 'b']
+    });
+  });
+
+  it('tests validate body with error', async function() {
+    const next = sandbox.stub();
+    const ctx = { request: { body: { keyNumber: 'somestring' } } } as any;
+    await validateBody(schema)(ctx, next).should.be.rejectedWith(
+      JSON.stringify({ keyNumber: '"keyNumber" must be a number' })
+    );
+    next.called.should.be.equal(false);
+  });
+
+  it('tests validate query string', async function() {
+    const next = sandbox.stub();
+    const ctx = {
+      query: {
+        keyString: 'somestring',
+        keyNumber: '2',
+        keyBoolean: 'true',
+        keyStringArray: ['a', 'b']
+      }
+    } as any;
+
+    await validateQueryString(schema)(ctx, next);
+    next.calledOnce.should.be.equal(true);
+  });
+
+  it('tests validate query string with error', async function() {
+    const next = sandbox.stub();
+    const ctx = { query: { keyNumber: 'somestring' } } as any;
+    await validateQueryString(schema)(ctx, next).should.be.rejectedWith(
+      JSON.stringify({ keyNumber: '"keyNumber" must be a number' })
+    );
+    next.called.should.be.equal(false);
+  });
+});


### PR DESCRIPTION
Solves https://github.com/Workable/orka/issues/129
This functionality keeps being duplicated across sourcing apps.

- Add validate-params and expose methods
- Add @hapi/joi as a dependency (not injected, it's something that it makes sense to be controlled via orka)
- Refactored validation logic (taken from campaigns).
- Added TODO for validateQueryString (as is now, we only validate, but we do not store the cast result in  order to use it later on, all params remain as text)

One idea would be to add them in request.body as well, and depending on the order of the validation (for a request that contains both body and query params) the caller can set which param will remain (override logic). e.g.

POST localhost:3000/testPost?key=2
{
   "key": 3
}

depending on the validation we could either throw an assertion error, or just keep one of the two. For:
- validateQueryString(), validateBody() -> keep body (3)
- validateBody(), validateQueryString() -> keep query param (2)