### PR TITLE
Add defaultRouter in orka

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1901,9 +1901,9 @@
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-koa-router": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fast-koa-router/-/fast-koa-router-1.1.0.tgz",
-      "integrity": "sha512-iU8TodjCOxVU+uTjAG4VrJALhX8Rz6YhDk9OjUuLlXj8Gomh34CWqJAzL//VaZ/D5akY1rwJjd6nios4f5mSGA=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-koa-router/-/fast-koa-router-1.2.0.tgz",
+      "integrity": "sha512-0gye+CqaFa7V4w4uJk799JZf9Rcl//OVGYIOLmdfTHB85ueLsmCjE7T0QuTd7OuC/JIg8Gr9sbWT0Nzbl8FUuA=="
     },
     "fast-text-encoding": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@workablehr/riviere": "^1.6.0",
     "codependency": "^2.1.0",
     "diamorphosis": "^0.8.1",
-    "fast-koa-router": "^1.1.0",
+    "fast-koa-router": "^1.2.0",
     "honeybadger": "^1.3.0",
     "koa": "^2.11.0",
     "koa-bodyparser": "^4.2.1",

--- a/src/orka-builder.ts
+++ b/src/orka-builder.ts
@@ -24,6 +24,7 @@ import * as Koa from 'koa';
 export default class OrkaBuilder {
   options: Partial<OrkaOptions>;
   config: any;
+  defaultRouter: ReturnType<typeof router>;
   middlewares: Middleware<any>[];
   koaTasks: ((
     app: Koa<any, {}>,
@@ -146,7 +147,8 @@ export default class OrkaBuilder {
     return this.use(() => {
       let routes = require(path.resolve(m));
       routes = routes.default && Object.keys(routes).length === 1 ? routes.default : routes;
-      return router(routes);
+      this.defaultRouter = router(routes);
+      return this.defaultRouter;
     });
   }
 


### PR DESCRIPTION
This could be used in repl (eg node-nc) to easily check routes eg:

orka.defaultRouter.matching('/api/v1/foo');

or

orka.defaultRouter.routes to see all routes;