### PR TITLE
Adds autoOffsetReset option for kafka consumers

### DIFF
--- a/src/initializers/kafka/base-kafka-handler.ts
+++ b/src/initializers/kafka/base-kafka-handler.ts
@@ -8,13 +8,18 @@ export default abstract class BaseKafkaHandler<Input, Output> {
   topic: string;
   batchSize: number;
   logger: Logger;
+  autoOffsetReset: string;
 
-  constructor(kafka: Kafka, options: { topic: string; logger: Logger; batchSize?: number }) {
-    const { topic, batchSize, logger } = options;
+  constructor(
+    kafka: Kafka,
+    options: { topic: string; logger: Logger; batchSize?: number; autoOffsetReset?: 'earliest' | 'latest' }
+  ) {
+    const { topic, batchSize, logger, autoOffsetReset } = options;
     this.topic = topic;
     this.batchSize = batchSize || 1;
+    this.autoOffsetReset = autoOffsetReset || 'earliest';
     this.logger = logger;
-    this.consumer = kafka.createConsumer(this.topic);
+    this.consumer = kafka.createConsumer(this.topic, <'earliest' | 'latest'>this.autoOffsetReset);
     this.consumer.connect().then(() => {
       this.logger.info(`Kafka consumer connected to topic: ${this.topic}`);
       this.consume().catch(err => this.logger.error(err));

--- a/src/initializers/kafka/kafka.ts
+++ b/src/initializers/kafka/kafka.ts
@@ -30,7 +30,7 @@ export default class Kafka {
     getLogger('orka.kafka.send').info(`partition(${_partition})[${offset}][${_key}] produced for topic ${topic}`);
   }
 
-  public createConsumer(topic: string) {
+  public createConsumer(topic: string, autoOffsetReset?: 'earliest' | 'latest') {
     const { groupId, brokers } = this.options;
     const config = {
       groupId,
@@ -45,7 +45,7 @@ export default class Kafka {
         ...this.authOptions
       },
       tconf: {
-        'auto.offset.reset': <'earliest'>'earliest'
+        'auto.offset.reset': autoOffsetReset || <'earliest'>'earliest'
       }
     };
 

--- a/test/initializers/kafka/base-kafka-handler.test.ts
+++ b/test/initializers/kafka/base-kafka-handler.test.ts
@@ -11,36 +11,64 @@ const logger = {
 } as any;
 
 describe('base kafka handler class', async () => {
-  const cbStub = sinon.stub();
-  const handleStub = sinon.stub();
-  const producerStub = { connect: sandbox.stub(), on: sandbox.stub(), send: sandbox.stub().returns({}) };
-  const consumeStub = {
-    connect: sinon.stub().returns(Promise.resolve()),
-    commit: sinon.stub(),
-    consume: sinon.stub().callsFake(async fn => await fn({ value: 'msg' }, cbStub))
-  };
+  let cbStub, handleStub, producerStub, consumeStub;
+
   class TestKafkaHandler extends BaseKafkaHandler<any, any> {
     public async handle(...args) {
       handleStub(args);
     }
   }
 
+  function assertConsume() {
+    consumeStub.connect.calledOnce.should.be.true();
+    consumeStub.consume.calledOnce.should.be.true();
+    consumeStub.commit.calledOnce.should.be.true();
+    handleStub.calledOnce.should.be.true();
+    cbStub.calledOnce.should.be.true();
+    handleStub.calledWith('msg');
+    consumeStub.commit.calledWith(false);
+  }
+
+  beforeEach(() => {
+    cbStub = sinon.stub();
+    handleStub = sinon.stub();
+    producerStub = { connect: sandbox.stub(), on: sandbox.stub(), send: sandbox.stub().returns({}) };
+    consumeStub = {
+      connect: sinon.stub().returns(Promise.resolve()),
+      commit: sinon.stub(),
+      consume: sinon.stub().callsFake(async fn => await fn({ value: 'msg' }, cbStub))
+    };
+  });
+
   afterEach(() => {
     sandbox.restore();
   });
 
-  it('should call correct methods with correct args', async () => {
-    sandbox.stub(Kafka.prototype, 'createProducer').returns(producerStub);
-    sandbox.stub(Kafka.prototype, 'createConsumer').returns(consumeStub);
-    const kafka = new Kafka({ groupId: 'groupId', clientId: 'clientId', brokers: [] } as any);
-    const handler = new TestKafkaHandler(kafka, { topic: 'topic', logger, batchSize: 2 });
-    await new Promise(resolve => setTimeout(resolve, 10));
-    consumeStub.connect.calledOnce.should.eql(true);
-    consumeStub.consume.calledOnce.should.eql(true);
-    consumeStub.commit.calledOnce.should.eql(true);
-    handleStub.calledOnce.should.eql(true);
-    cbStub.calledOnce.should.eql(true);
-    handleStub.calledWith('msg');
-    consumeStub.commit.calledWith(false);
+  describe('with default autoOffsetReset', () => {
+    it('should call correct methods with correct args', async () => {
+      sandbox.stub(Kafka.prototype, 'createProducer').returns(producerStub);
+      const createConsumer = sandbox.stub(Kafka.prototype, 'createConsumer').returns(consumeStub);
+      const kafka = new Kafka({ groupId: 'groupId', clientId: 'clientId', brokers: [] } as any);
+      const handler = new TestKafkaHandler(kafka, { topic: 'topic', logger, batchSize: 2 });
+      await new Promise(resolve => setTimeout(resolve, 10));
+      sandbox.assert.calledOnce(createConsumer);
+      sandbox.assert.calledWith(createConsumer, 'topic');
+      handler.autoOffsetReset.should.be.equal('earliest');
+      assertConsume();
+    });
+  });
+
+  describe('with autoOffsetReset latest', () => {
+    it('should call correct methods with correct args', async () => {
+      sandbox.stub(Kafka.prototype, 'createProducer').returns(producerStub);
+      const createConsumer = sandbox.stub(Kafka.prototype, 'createConsumer').returns(consumeStub);
+      const kafka = new Kafka({ groupId: 'groupId', clientId: 'clientId', brokers: [] } as any);
+      const handler = new TestKafkaHandler(kafka, { topic: 'topic', logger, batchSize: 2, autoOffsetReset: 'latest' });
+      await new Promise(resolve => setTimeout(resolve, 10));
+      sandbox.assert.calledOnce(createConsumer);
+      sandbox.assert.calledWith(createConsumer, 'topic', 'latest');
+      handler.autoOffsetReset.should.be.equal('latest');
+      assertConsume();
+    });
   });
 });


### PR DESCRIPTION
## With this PR: 
You can configure the `auto.offset.reset` property to `earliest` or `latest`.

Orka 's default remains `earliest` in order to be backwards compatible.
However [Kaflka's default seems to be](https://kafka.apache.org/documentation/#consumerconfigs) `latest`