### PR TITLE
Support rabbit-queue v5 (different publisher and consumer, no log4js)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@workablehr/orka",
-  "version": "0.27.0",
+  "version": "0.28.0-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4596,9 +4596,9 @@
       "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
     },
     "rabbit-queue": {
-      "version": "5.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/rabbit-queue/-/rabbit-queue-5.0.0-beta.1.tgz",
-      "integrity": "sha512-VCpemGZEigs4cT9PUnGW6cCN7CvdGm31yRmfN9ojtzj/NOSkyM5AxablEv6kQlLCPacs6B61EzqBK1GHACWbvw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/rabbit-queue/-/rabbit-queue-5.0.0.tgz",
+      "integrity": "sha512-UfDKtVeBXGIeMeAET9HUwGr06tqJjxXx+9wCXzxltOeKQrm/XALsoO4LijLH//vJjx5X62Az58YtaHvqjm7Gmg==",
       "requires": {
         "amqplib": "^0.5.5",
         "race-until": "^2.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -238,11 +238,6 @@
         "@hapi/hoek": "^9.0.0"
       }
     },
-    "@log4js-node/log4js-api": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@log4js-node/log4js-api/-/log4js-api-1.0.2.tgz",
-      "integrity": "sha512-6SJfx949YEWooh/CUPpJ+F491y4BYJmknz4hUN1+RHvKoUEynKbRmhnwbk/VLmh4OthLLDNCyWXfbh4DG1cTXA=="
-    },
     "@newrelic/koa": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@newrelic/koa/-/koa-1.0.8.tgz",
@@ -4601,20 +4596,26 @@
       "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
     },
     "rabbit-queue": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/rabbit-queue/-/rabbit-queue-4.6.0.tgz",
-      "integrity": "sha512-dpFYzbq27Njz8PJJDYOJjxhpBOk+uUrBCUvDo444+Vv36A6yrz77v5gQAg8rFsmeRadleIBfOnMeaO9bFBJpwQ==",
+      "version": "5.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/rabbit-queue/-/rabbit-queue-5.0.0-beta.1.tgz",
+      "integrity": "sha512-VCpemGZEigs4cT9PUnGW6cCN7CvdGm31yRmfN9ojtzj/NOSkyM5AxablEv6kQlLCPacs6B61EzqBK1GHACWbvw==",
       "requires": {
-        "@log4js-node/log4js-api": "^1.0.0",
         "amqplib": "^0.5.5",
         "race-until": "^2.2.0",
-        "uuid": "^3.0.1"
+        "uuid": "^7.0.0"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+          "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="
+        }
       }
     },
     "race-until": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/race-until/-/race-until-2.2.0.tgz",
-      "integrity": "sha512-5BGJ80iPgx3DPrin9vzx1DE56i6/7qfVyN+pUcme5RWnmB9BvjikK9b+0z0xrz6EF2mH8+3JKrbgVb5O1fAUXA=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/race-until/-/race-until-2.3.1.tgz",
+      "integrity": "sha512-NUpJpbEaZ3FL5UprkqzvvsY5HNEfJ8s1ba+MtQGdGBskm5u1K4tX546oi7BOjkw3LTtykOPQ///a7nKGEUd3uQ=="
     },
     "raw-body": {
       "version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "lodash": "^4.17.15",
     "log4js": "^4.2.0",
     "mongoose": "^5.7.11",
-    "rabbit-queue": "^4.6.0",
+    "rabbit-queue": "*",
     "redis": "^2.8.0",
     "source-map-support": "^0.5.16",
     "tmp": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workablehr/orka",
-  "version": "0.27.0",
+  "version": "0.28.0-beta.0",
   "description": "",
   "main": "build/index.js",
   "scripts": {

--- a/src/initializers/log4js/index.ts
+++ b/src/initializers/log4js/index.ts
@@ -8,8 +8,12 @@ let tmp = name => {
 };
 
 export let getLogger = name => {
-  return tmp(name);
+  if (loggers[name]) return loggers[name];
+
+  loggers[name] = tmp(name);
+  return loggers[name];
 };
+const loggers = {};
 
 export default async config => {
   let appenders = {} as any;

--- a/src/initializers/rabbitmq/index.ts
+++ b/src/initializers/rabbitmq/index.ts
@@ -5,6 +5,7 @@ import * as RabbitType from 'rabbit-queue';
 import * as lodash from 'lodash';
 
 const logger = getLogger('orka.rabbit');
+const rabbitLogger = getLogger('RMQ');
 
 let connection: RabbitType.Rabbit;
 let shouldReconnect: Boolean = true;
@@ -48,6 +49,7 @@ export default (config, orkaOptions: Partial<OrkaOptions>) => {
       setTimeout(() => connection.reconnect(), config.queue.connectDelay);
     }
   });
+  connection.on('log', (component, level, ...args) => rabbitLogger[level](component, ...args));
 };
 
 export const getRabbit = () => {

--- a/src/initializers/rabbitmq/index.ts
+++ b/src/initializers/rabbitmq/index.ts
@@ -5,7 +5,6 @@ import * as RabbitType from 'rabbit-queue';
 import * as lodash from 'lodash';
 
 const logger = getLogger('orka.rabbit');
-const rabbitLogger = getLogger('RMQ');
 
 let connection: RabbitType.Rabbit;
 let shouldReconnect: Boolean = true;
@@ -49,7 +48,7 @@ export default (config, orkaOptions: Partial<OrkaOptions>) => {
       setTimeout(() => connection.reconnect(), config.queue.connectDelay);
     }
   });
-  connection.on('log', (component, level, ...args) => rabbitLogger[level](component, ...args));
+  connection.on('log', (component, level, ...args) => getLogger(component)[level](component, ...args));
 };
 
 export const getRabbit = () => {


### PR DESCRIPTION
getLogger memoizes logger by name. (It was the default behavior of log4js in previou versions).
Latest rabbit-queue supports different publisher and consumer. It also has dropped support for log4js that's why a on('log') listener was needed.