### PR TITLE
[CAN-2238] Add prefixes that return * for allowed origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ config = {
   cors: {
     allowedOrigins: ['localhost', 'lvh.me'],
     credentials: true, // Adds cors needed for exchanging cookies over https.
+    starPrefixes: ['/publicEndpoints/foo/bar'] // ctx.path prefixes that will return access-control-allow-origin: *
     …
   },
   traceHeaderName: 'X-Request-Id', // for logging in http requests

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ config = {
   cors: {
     allowedOrigins: ['localhost', 'lvh.me'],
     credentials: true, // Adds cors needed for exchanging cookies over https.
-    starPrefixes: ['/publicEndpoints/foo/bar'] // ctx.path prefixes that will return access-control-allow-origin: *
+    publicPrefixes: ['/publicEndpoints/foo/bar'] // ctx.path prefixes that will return access-control-allow-origin: *
     …
   },
   traceHeaderName: 'X-Request-Id', // for logging in http requests

--- a/examples/simple-example/config.js
+++ b/examples/simple-example/config.js
@@ -2,5 +2,8 @@ module.exports = {
   nodeEnv: 'demo',
   app: {
     name: 'foo'
+  },
+  cors: {
+    starPrefixes: ['/api/allowAll']
   }
 };

--- a/examples/simple-example/config.js
+++ b/examples/simple-example/config.js
@@ -4,6 +4,6 @@ module.exports = {
     name: 'foo'
   },
   cors: {
-    starPrefixes: ['/api/allowAll']
+    publicPrefixes: ['/api/allowAll']
   }
 };

--- a/examples/simple-example/routes.js
+++ b/examples/simple-example/routes.js
@@ -11,7 +11,8 @@ module.exports = {
     '/logError': async (ctx, next) => {
       getLogger('log').error(new Error('test'), 'this was a test error', { context: 'foo' });
       ctx.throw(new Error('test'), 505);
-    }
+    },
+    '/api/allowAll/accounts/:subdomain': async (ctx, next) => (ctx.body = 'ok')
   },
   policy: {
     '/testPolicy': async (ctx, next) => {

--- a/src/orka-builder.ts
+++ b/src/orka-builder.ts
@@ -68,13 +68,16 @@ export default class OrkaBuilder {
     return this;
   }
 
-  useCors({ credentials = undefined, allowedOrigins = this.config.allowedOrigins } = this.config.cors || {}) {
+  useCors(
+    { credentials = undefined, allowedOrigins = this.config.allowedOrigins, starPrefixes = [] } = this.config.cors || {}
+  ) {
     const allowedOrigin = new RegExp('https?://(www\\.)?([^.]+\\.)?(' + allowedOrigins.join(')|(') + ')');
 
     return this.use(() =>
       cors({
         origin: (ctx: Context) => {
           const origin = ctx.request.headers.origin || ctx.request.origin;
+          if (starPrefixes.some(p => ctx.path.startsWith(p))) return '*';
           return allowedOrigin.test(origin) ? origin : allowedOrigins[0];
         },
         credentials

--- a/src/orka-builder.ts
+++ b/src/orka-builder.ts
@@ -69,7 +69,8 @@ export default class OrkaBuilder {
   }
 
   useCors(
-    { credentials = undefined, allowedOrigins = this.config.allowedOrigins, starPrefixes = [] } = this.config.cors || {}
+    { credentials = undefined, allowedOrigins = this.config.allowedOrigins, publicPrefixes = [] } = this.config.cors ||
+      {}
   ) {
     const allowedOrigin = new RegExp('https?://(www\\.)?([^.]+\\.)?(' + allowedOrigins.join(')|(') + ')');
 
@@ -77,7 +78,7 @@ export default class OrkaBuilder {
       cors({
         origin: (ctx: Context) => {
           const origin = ctx.request.headers.origin || ctx.request.origin;
-          if (starPrefixes.some(p => ctx.path.startsWith(p))) return '*';
+          if (publicPrefixes.some(p => ctx.path.startsWith(p))) return '*';
           return allowedOrigin.test(origin) ? origin : allowedOrigins[0];
         },
         credentials

--- a/test/examples/star-cors-example.test.ts
+++ b/test/examples/star-cors-example.test.ts
@@ -1,0 +1,32 @@
+import 'should';
+import * as supertest from 'supertest';
+
+describe('Star CORS examples', () => {
+  let server;
+  after(async () => {
+    if (server) await server.stop();
+  });
+
+  before(async () => {
+    const serverPath = '../../examples/simple-example/app';
+    delete require.cache[require.resolve(serverPath)];
+    server = require(serverPath);
+    await server.start();
+    await new Promise(t => setTimeout(t, 1000));
+  });
+
+  it('/api/allowAll/ returns access-control-allow-origin *', async () => {
+    const response = await supertest('localhost:3000')
+      .get('/api/allowAll/accounts/banana')
+      .expect(200);
+
+    response.headers['access-control-allow-origin'].should.eql('*');
+  });
+  it('/health/ returns access-control-allow-origin localhost:3000', async () => {
+    const response = await supertest('localhost:3000')
+      .get('/health')
+      .expect(200);
+
+    response.headers['access-control-allow-origin'].should.eql('http://localhost:3000');
+  });
+});


### PR DESCRIPTION
## Summary
We need to serve some endpoints in careers-page with `access-control-allow-origin: *`

Endpoints accessible to everyone 