### PR TITLE
[CAN-2661] Separate kafka consumer/producer connection strings

### DIFF
--- a/src/initializers/diamorphosis.ts
+++ b/src/initializers/diamorphosis.ts
@@ -34,7 +34,7 @@ export default (config, orkaOptions: Partial<OrkaOptions>) => {
   };
   if (config.kafka) {
     config.kafka.producer = {
-      brokers: [],
+      brokers: [...config.kafka.producer?.brokers],
       certificates: {
         key: '',
         cert: '',

--- a/src/initializers/diamorphosis.ts
+++ b/src/initializers/diamorphosis.ts
@@ -34,7 +34,7 @@ export default (config, orkaOptions: Partial<OrkaOptions>) => {
   };
   if (config.kafka) {
     config.kafka.producer = {
-      brokers: [...config.kafka.producer?.brokers],
+      brokers: [...(config.kafka.producer?.brokers || [])],
       certificates: {
         key: '',
         cert: '',

--- a/src/initializers/diamorphosis.ts
+++ b/src/initializers/diamorphosis.ts
@@ -2,40 +2,6 @@ import * as diamorphosis from 'diamorphosis';
 import { OrkaOptions } from '../typings/orka';
 import { defaultTo, isBoolean } from 'lodash';
 
-export const producerConfigOverrides = config => {
-  const {
-    KAFKA_PRODUCER_BROKERS,
-    KAFKA_PRODUCER_CERTIFICATES_KEY,
-    KAFKA_PRODUCER_CERTIFICATES_CERT,
-    KAFKA_PRODUCER_CERTIFICATES_CA,
-    KAFKA_PRODUCER_SASL_USERNAME,
-    KAFKA_PRODUCER_SASL_PASSWORD
-  } = process.env;
-
-  if (!KAFKA_PRODUCER_BROKERS) {
-    return {
-      ...config.kafka.producer,
-      brokers: config.kafka.brokers,
-      certificates: config.kafka.certificates,
-      sasl: config.kafka.sasl
-    };
-  }
-
-  return {
-    ...config.kafka.producer,
-    brokers: KAFKA_PRODUCER_BROKERS?.split(','),
-    certificates: {
-      key: KAFKA_PRODUCER_CERTIFICATES_KEY,
-      cert: KAFKA_PRODUCER_CERTIFICATES_CERT,
-      ca: KAFKA_PRODUCER_CERTIFICATES_CA
-    },
-    sasl: {
-      username: KAFKA_PRODUCER_SASL_USERNAME,
-      password: KAFKA_PRODUCER_SASL_PASSWORD
-    }
-  };
-};
-
 export default (config, orkaOptions: Partial<OrkaOptions>) => {
   config.nodeEnv = config.nodeEnv || 'development';
   config.app = {
@@ -66,11 +32,34 @@ export default (config, orkaOptions: Partial<OrkaOptions>) => {
     headersRegex: '^X-.*',
     ...config.riviere
   };
+  if (config.kafka) {
+    config.kafka.producer = {
+      brokers: [],
+      certificates: {
+        key: '',
+        cert: '',
+        ca: '',
+        ...config.kafka.producer?.certificates
+      },
+      sasl: {
+        username: '',
+        password: '',
+        ...config.kafka.producer?.sasl
+      },
+      ...config.kafka.producer
+    };
+  }
   diamorphosis(orkaOptions.diamorphosis);
   config.app.env = config.app.env || config.nodeEnv;
-  // Separate kafka producer/consumer connection strings
-  if (config.kafka) {
-    config.kafka.producer = producerConfigOverrides(config);
+
+  // Override kafka producer config with defaults if brokers is not set
+  if (config.kafka && (!config.kafka.producer?.brokers || config.kafka.producer.brokers.length === 0)) {
+    config.kafka.producer = {
+      ...config.kafka.producer,
+      brokers: config.kafka.brokers,
+      certificates: config.kafka.certificates,
+      sasl: config.kafka.sasl
+    };
   }
 
   if (config.log.console === '') {

--- a/src/typings/kafka.d.ts
+++ b/src/typings/kafka.d.ts
@@ -11,6 +11,18 @@ export interface KafkaConfig {
   groupId: string;
   clientId: string;
   brokers: string[];
+  producer: {
+    brokers: string[];
+    certificates?: {
+      key: string;
+      cert: string;
+      ca: string;
+    };
+    sasl?: {
+      username: string;
+      password: string;
+    };
+  };
 }
 
 export interface KafkaHealthConfig {

--- a/test/diamorphosis/config.js
+++ b/test/diamorphosis/config.js
@@ -1,3 +1,16 @@
 module.exports = {
-  nodeEnv: 'diamorphosis_env'
+  nodeEnv: 'diamorphosis_env',
+  kafka: {
+    brokers: ['confluent'],
+    certificates: {
+      ca: 'ca',
+      key: 'key',
+      cert: 'cert'
+    },
+    producer: {
+      topics: {
+        topic1: 'topic1'
+      }
+    }
+  }
 };

--- a/test/diamorphosis/diamorphosis.test.ts
+++ b/test/diamorphosis/diamorphosis.test.ts
@@ -1,4 +1,4 @@
-import diamorphosis, { producerConfigOverrides } from '../../src/initializers/diamorphosis';
+import diamorphosis from '../../src/initializers/diamorphosis';
 import { OrkaOptions } from '../../src/typings/orka';
 import * as path from 'path';
 import { assert } from 'console';
@@ -86,9 +86,9 @@ describe('Diamorphosis Test', () => {
       config.kafka.producer.should.eql({
         brokers: ['confluent1', 'confluent2'],
         certificates: {
-          ca: undefined,
-          cert: undefined,
-          key: undefined
+          ca: '',
+          cert: '',
+          key: ''
         },
         sasl: {
           username: 'producer username',
@@ -241,58 +241,6 @@ describe('Diamorphosis Test', () => {
         config.log.console.should.equal(true);
         config.log.json.should.equal(true);
         config.riviere.styles.should.eql(['json']);
-      });
-    });
-  });
-
-  describe('producerConfigOverrides', function() {
-    let config = {
-      kafka: {
-        brokers: ['confluent'],
-        certificates: {
-          ca: 'ca',
-          key: 'key',
-          cert: 'cert'
-        },
-        producer: {
-          option: 'an option'
-        }
-      }
-    };
-    beforeEach(() => {
-      process.env = {};
-    });
-    it('should return defaults if KAFKA_PRODUCER_BROKERS is not defined', () => {
-      producerConfigOverrides(config).should.eql({
-        option: 'an option',
-        brokers: ['confluent'],
-        certificates: {
-          ca: 'ca',
-          key: 'key',
-          cert: 'cert'
-        },
-        sasl: undefined
-      });
-    });
-
-    it('should return producer env if KAFKA_PRODUCER_BROKERS is defined', () => {
-      process.env = {
-        KAFKA_PRODUCER_BROKERS: 'aiven1,aiven2',
-        KAFKA_PRODUCER_SASL_USERNAME: 'producer username',
-        KAFKA_PRODUCER_SASL_PASSWORD: 'producer password'
-      };
-      producerConfigOverrides(config).should.eql({
-        brokers: process.env.KAFKA_PRODUCER_BROKERS.split(','),
-        option: 'an option',
-        sasl: {
-          username: process.env.KAFKA_PRODUCER_SASL_USERNAME,
-          password: process.env.KAFKA_PRODUCER_SASL_PASSWORD
-        },
-        certificates: {
-          ca: undefined,
-          cert: undefined,
-          key: undefined
-        }
       });
     });
   });

--- a/test/diamorphosis/diamorphosis.test.ts
+++ b/test/diamorphosis/diamorphosis.test.ts
@@ -1,7 +1,7 @@
 import diamorphosis from '../../src/initializers/diamorphosis';
 import { OrkaOptions } from '../../src/typings/orka';
 import * as path from 'path';
-import { assert } from 'console';
+import * as assert from 'assert';
 
 describe('Diamorphosis Test', () => {
   describe('should set environment variables', () => {
@@ -61,9 +61,7 @@ describe('Diamorphosis Test', () => {
     });
 
     it('noop if kafka not exist in config', () => {
-      process.env = {
-        KAFKA_PRODUCER_BROKERS: 'confluent1,confluent2'
-      };
+      process.env.KAFKA_PRODUCER_BROKERS = 'confluent1,confluent2';
 
       const config = require(options.diamorphosis.configPath);
       delete config.kafka;
@@ -73,11 +71,9 @@ describe('Diamorphosis Test', () => {
     });
 
     it('kafka.producer options should set if exist in process.env', () => {
-      process.env = {
-        KAFKA_PRODUCER_BROKERS: 'confluent1,confluent2',
-        KAFKA_PRODUCER_SASL_USERNAME: 'producer username',
-        KAFKA_PRODUCER_SASL_PASSWORD: 'producer password'
-      };
+      process.env.KAFKA_PRODUCER_BROKERS = 'confluent1,confluent2';
+      process.env.KAFKA_PRODUCER_SASL_USERNAME = 'producer username';
+      process.env.KAFKA_PRODUCER_SASL_PASSWORD = 'producer password';
 
       const config = require(options.diamorphosis.configPath);
 

--- a/test/initializers/kafka/kafka.test.ts
+++ b/test/initializers/kafka/kafka.test.ts
@@ -29,7 +29,10 @@ describe('kafka class', () => {
       },
       groupId: 'groupId',
       clientId: 'clientId',
-      brokers: []
+      brokers: [],
+      producer: {
+        brokers: ['broker1']
+      }
     });
     await kafka.connect();
     producerStub.connect.calledOnce.should.eql(true);


### PR DESCRIPTION
## Summary
Separates kafka consumer & producer configuration. From now on producer uses the following env variables:
* `KAFKA_PRODUCER_BROKERS`
* `KAFKA_PRODUCER_CERTIFICATES_KEY`
* `KAFKA_PRODUCER_CERTIFICATES_CERT`
* `KAFKA_PRODUCER_CERTIFICATES_CA`
* `KAFKA_PRODUCER_SASL_USERNAME`
* `KAFKA_PRODUCER_SASL_PASSWORD`

If `KAFKA_PRODUCER_BROKERS` is not provided then the global kafka options will be used for producer.  (`KAFKA_BROKERS`, `KAFKA_CERTIFICATES_KEY`, `KAFKA_CERTIFICATES_CERT`, `KAFKA_CERTIFICATES_CA`, `KAFKA_PRODUCER_SASL_USERNAME`, `KAFKA_SASL_PASSWORD`)

P.S. This change requires no amendments on the apps. They only need to bump orka and set the env variables (no need for config.js change).