### PR TITLE
Allow consumer to consume multiple topics

### DIFF
--- a/src/initializers/kafka/base-kafka-handler.ts
+++ b/src/initializers/kafka/base-kafka-handler.ts
@@ -5,14 +5,14 @@ import { NConsumer, KafkaMessage } from '../../typings/kafka';
 
 export default abstract class BaseKafkaHandler<Input, Output> {
   consumer: NConsumer;
-  topic: string;
+  topic: string | string[];
   batchSize: number;
   logger: Logger;
   autoOffsetReset: string;
 
   constructor(
     kafka: Kafka,
-    options: { topic: string; logger: Logger; batchSize?: number; autoOffsetReset?: 'earliest' | 'latest' }
+    options: { topic: string | string[]; logger: Logger; batchSize?: number; autoOffsetReset?: 'earliest' | 'latest' }
   ) {
     const { topic, batchSize, logger, autoOffsetReset } = options;
     this.topic = topic;

--- a/src/initializers/kafka/kafka.ts
+++ b/src/initializers/kafka/kafka.ts
@@ -43,7 +43,7 @@ export default class Kafka {
     getLogger('orka.kafka.send').info(`partition(${_partition})[${offset}][${_key}] produced for topic ${topic}`);
   }
 
-  public createConsumer(topic: string, autoOffsetReset?: 'earliest' | 'latest') {
+  public createConsumer(topic: string | string[], autoOffsetReset?: 'earliest' | 'latest') {
     const { groupId, brokers } = this.options;
     const config = {
       groupId,

--- a/src/initializers/kafka/kafka.ts
+++ b/src/initializers/kafka/kafka.ts
@@ -9,6 +9,7 @@ export default class Kafka {
   private producer: NProducer;
   private options: KafkaConfig;
   private authOptions: any;
+  private _metadata: any;
 
   constructor(options: KafkaConfig) {
     this.options = options;
@@ -22,6 +23,7 @@ export default class Kafka {
     const logger = getLogger('orka.kafka.connect');
     this.producer.on('error', err => logger.error(err));
     await this.producer.connect();
+    this._metadata = await this.producer.getMetadata(5000);
     logger.info(`Kafka producer connected ${producer?.brokers?.join(', ') || brokers.join(', ')}`);
   }
 
@@ -41,6 +43,10 @@ export default class Kafka {
       headers
     );
     getLogger('orka.kafka.send').info(`partition(${_partition})[${offset}][${_key}] produced for topic ${topic}`);
+  }
+
+  public metadata() {
+    return this._metadata;
   }
 
   public createConsumer(topic: string | string[], autoOffsetReset?: 'earliest' | 'latest') {

--- a/test/initializers/kafka/base-kafka-handler.test.ts
+++ b/test/initializers/kafka/base-kafka-handler.test.ts
@@ -44,6 +44,17 @@ describe('base kafka handler class', async () => {
     sandbox.restore();
   });
 
+  it('should call consumer with multiple topics', async () => {
+    sandbox.stub(Kafka.prototype, 'createProducer').returns(producerStub);
+    const createConsumer = sandbox.stub(Kafka.prototype, 'createConsumer').returns(consumeStub);
+    const kafka = new Kafka({ groupId: 'groupId', clientId: 'clientId', brokers: [] } as any);
+    const handler = new TestKafkaHandler(kafka, { topic: ['topic1', 'topic2'], logger, batchSize: 2 });
+    await new Promise(resolve => setTimeout(resolve, 10));
+    sandbox.assert.calledOnce(createConsumer);
+    sandbox.assert.calledWith(createConsumer, ['topic1', 'topic2']);
+    assertConsume();
+  });
+
   describe('with default autoOffsetReset', () => {
     it('should call correct methods with correct args', async () => {
       sandbox.stub(Kafka.prototype, 'createProducer').returns(producerStub);

--- a/test/initializers/kafka/kafka.test.ts
+++ b/test/initializers/kafka/kafka.test.ts
@@ -7,7 +7,12 @@ import * as fs from 'fs';
 const sandbox = sinon.createSandbox();
 
 describe('kafka class', () => {
-  const producerStub = { connect: sandbox.stub(), on: sandbox.stub(), send: sandbox.stub().returns({}) };
+  const producerStub = {
+    connect: sandbox.stub(),
+    getMetadata: sandbox.stub(),
+    on: sandbox.stub(),
+    send: sandbox.stub().returns({})
+  };
   const consumeStub = {};
   before(() => {
     sandbox.stub(fs, 'writeFileSync');
@@ -38,6 +43,7 @@ describe('kafka class', () => {
     producerStub.connect.calledOnce.should.eql(true);
     producerStub.on.calledOnce.should.eql(true);
     producerStub.connect.calledOnce.should.eql(true);
+    producerStub.getMetadata.calledOnce.should.eql(true);
     producerStub.on.calledWith('error').should.eql(true);
 
     await kafka.send('topic', 'msg');


### PR DESCRIPTION
## Summary 
* Kafka consumer can consume multiple topics, but we limit it to one
* Expose broker metadata to apps