### PR TITLE
Send error name to honeybadger

### DIFF
--- a/src/initializers/log4js/honeybadger-appender.ts
+++ b/src/initializers/log4js/honeybadger-appender.ts
@@ -3,7 +3,7 @@ import * as Honeybadger from 'honeybadger';
 const Levels = require('log4js/lib/levels');
 const log4jsErrorLevel = Levels.ERROR.level;
 
-function notifyHoneybadger(name, error, ...rest) {
+function notifyHoneybadger(categoryName, error, ...rest) {
   if (typeof error === 'string') {
     error = new Error(error);
   }
@@ -28,14 +28,14 @@ function notifyHoneybadger(name, error, ...rest) {
   delete context.action;
   delete context.component;
 
-  let { headers = {}, action = actionFallback, component = componentFallback, params = {} } = error;
+  let { headers = {}, action = actionFallback, component = componentFallback, params = {}, name } = error;
 
   Object.assign(context, error.context);
 
-  const computedComponent = component || name;
+  const computedComponent = component || categoryName;
 
   Honeybadger.notify(
-    { stack: error.stack, message },
+    { stack: error.stack, message, name },
     {
       context,
       headers,
@@ -45,7 +45,7 @@ function notifyHoneybadger(name, error, ...rest) {
       action,
       component: computedComponent,
       params,
-      fingerprint: action && computedComponent ? `${computedComponent}_${action}` : name
+      fingerprint: action && computedComponent ? `${computedComponent}_${action}` : categoryName
     }
   );
 }

--- a/test/initializers/log4js/honeybadger-appender.test.ts
+++ b/test/initializers/log4js/honeybadger-appender.test.ts
@@ -106,6 +106,7 @@ describe('log4js_honeybadger_appender', () => {
     err.status = 200;
     err.component = 'testController';
     err.action = '/test/endpoint';
+    err.name = 'CustomName';
     appender.configure()({
       level: {
         level: 40000
@@ -115,6 +116,7 @@ describe('log4js_honeybadger_appender', () => {
     });
     notifySpy.callCount.should.equal(1);
     notifySpy.args[0][0].message.should.equal('omg. a. b. c');
+    notifySpy.args[0][0].name.should.equal('CustomName');
   });
 
   it('should assign any additional json values to the context', () => {


### PR DESCRIPTION
Error names are sometimes extracted from stacktrace.
This will always also send the name to honeybadger.