### PR TITLE
make new relic app name configurable

### DIFF
--- a/src/initializers/newrelic/index.ts
+++ b/src/initializers/newrelic/index.ts
@@ -5,9 +5,7 @@ let newrelic;
 export default (config, appName: string) => {
   process.env.NEW_RELIC_HOME = __dirname;
   if (process.env.NEW_RELIC_LICENSE_KEY) {
-    if (!process.env.NEW_RELIC_APP_NAME) {
-      process.env.NEW_RELIC_APP_NAME = `${appName} ${config.app.env}`;
-    }
+    process.env.NEW_RELIC_APP_NAME = process.env.NEW_RELIC_APP_NAME || `${appName} ${config.app.env}`;
     newrelic = requireInjected('newrelic');
   }
 };

--- a/src/initializers/newrelic/index.ts
+++ b/src/initializers/newrelic/index.ts
@@ -5,7 +5,9 @@ let newrelic;
 export default (config, appName: string) => {
   process.env.NEW_RELIC_HOME = __dirname;
   if (process.env.NEW_RELIC_LICENSE_KEY) {
-    process.env.NEW_RELIC_APP_NAME = `${appName} ${config.app.env}`;
+    if (!process.env.NEW_RELIC_APP_NAME) {
+      process.env.NEW_RELIC_APP_NAME = `${appName} ${config.app.env}`;
+    }
     newrelic = requireInjected('newrelic');
   }
 };


### PR DESCRIPTION
Currently, new relic app name is automatically constructed and can't be changed. Although this is quite useful in most cases, there are some exceptions were we want to override that name. With this PR, the new relic app name can be configured using NEW_RELIC_APP_NAME