### PR TITLE
Improvements for Bull integration

### DIFF
--- a/examples/bull-example/metrics.js
+++ b/examples/bull-example/metrics.js
@@ -11,7 +11,7 @@ app
   .initTasks()
   .then(() => {
     const config = require('./config');
-    return getBull().startMetrics(config.bull.metricsSchedule);
+    return getBull().startMetrics(config.bull.metricsSchedule, 'kebabCase');
   })
   .catch(e => {
     console.error(e);

--- a/src/initializers/bull/bull.ts
+++ b/src/initializers/bull/bull.ts
@@ -111,7 +111,7 @@ const handleFailure = (name, job, error) => {
   if (job.attemptsMade === job.opts.attempts) {
     getLogger(name).error(error);
   } else {
-    getLogger(name).warn(`Job with ${job.id} failed. Attempt ${job.attemptsMade}/${job.opts.attempts} Retrying`);
+    getLogger(name).warn(`Job #${job.id} failed. Attempt ${job.attemptsMade}/${job.opts.attempts} Retrying`);
   }
 };
 

--- a/src/initializers/bull/bull.ts
+++ b/src/initializers/bull/bull.ts
@@ -1,9 +1,11 @@
-import { defaultsDeep, has, keyBy, map } from 'lodash';
+import * as _ from 'lodash';
 import * as cron from 'node-cron';
 import { getLogger } from '../log4js';
 import requireInjected from '../../require-injected';
 const Queue = requireInjected('bull');
 const newrelic = process.env.NEW_RELIC_LICENSE_KEY ? requireInjected('newrelic') : null;
+
+const caseModifiers = ['camelCase', 'snakeCase', 'lowerCase', 'upperCase', 'kebabCase', 'startCase'];
 
 export default class Bull {
   private logger = getLogger('orka.bull');
@@ -18,8 +20,8 @@ export default class Bull {
   constructor(prefix, queueOpts, defaultOptions, redisOpts) {
     this.prefix = prefix;
     this.defaultOptions = defaultOptions;
-    this.queueOpts = keyBy(queueOpts, 'name');
-    this.queueNames = map(queueOpts, 'name');
+    this.queueOpts = _.keyBy(queueOpts, 'name');
+    this.queueNames = _.map(queueOpts, 'name');
     this.redisOpts = redisOpts;
   }
 
@@ -27,7 +29,7 @@ export default class Bull {
     const fullName = `${this.prefix}:${name}`;
     const options = this.queueOpts[name].options;
     this.logger.info(`Creating Queue: ${fullName}`);
-    const defaultJobOptions = defaultsDeep({}, options, this.defaultOptions);
+    const defaultJobOptions = _.defaultsDeep({}, options, this.defaultOptions);
     const queue = new Queue(fullName, { redis: this.redisOpts, defaultJobOptions });
     queue
       .on('drained', () => {
@@ -44,10 +46,10 @@ export default class Bull {
   }
 
   public getQueue(name: string) {
-    if (!has(this.queueOpts, name)) {
+    if (!_.has(this.queueOpts, name)) {
       throw new Error('no such queue');
     }
-    if (!has(this.instances, name)) {
+    if (!_.has(this.instances, name)) {
       this.createQueue(name);
     }
     return this.instances[name];
@@ -75,15 +77,16 @@ export default class Bull {
     }
   }
 
-  private async reportStats() {
+  private async reportStats(queueNameCase?: string) {
     const stats = await this.getStats();
+    const queueNameTransform = caseModifiers.includes(queueNameCase) ? _[queueNameCase] : _.camelCase;
     stats.forEach(entry => {
-      this.recordMetric(`Bull/Queues/${entry.queue}`, entry.count);
-      this.recordMetric(`Bull/QueuesFailed/${entry.queue}`, entry.failed);
+      this.recordMetric(`Bull/Queues/${queueNameTransform(entry.queue)}`, entry.count);
+      this.recordMetric(`Bull/QueuesFailed/${queueNameTransform(entry.queue)}`, entry.failed);
     });
   }
 
-  public startMetrics(cronExpression) {
+  public startMetrics(cronExpression, queueNameCase?: string) {
     if (!cron.validate(cronExpression)) {
       throw new Error(`Invalid cron expression: ${cronExpression}`);
     }
@@ -94,7 +97,7 @@ export default class Bull {
     const output = newrelic ? 'new relic' : 'logs';
     this.metricsTask = cron.schedule(cronExpression, async () => {
       getLogger('bull.metrics').info(`Sending queue metrics to ${output}`);
-      await this.reportStats();
+      await this.reportStats(queueNameCase);
     });
   }
 

--- a/test/initializers/bull/index.test.ts
+++ b/test/initializers/bull/index.test.ts
@@ -61,6 +61,13 @@ describe('bull init', () => {
       }
     }
   };
+  const moreRedisOpts = {
+    bull: {
+      redis: {
+        enableReadyCheck: true
+      }
+    }
+  };
   it('should handle the absence of bull config', async () => {
     await init({} as any, orkaOptions);
     should.throws(() => {
@@ -92,6 +99,18 @@ describe('bull init', () => {
         port: '6379',
         tls: { ca: ['bull-ca'], cert: 'bull-cert', key: 'bull-key' },
         enableReadyCheck: false
+      };
+      bull.redisOpts.should.be.eql(expectedRedisOpts);
+    });
+    it('should allow passing more redis options', async () => {
+      const config = merge({}, baseConfig, orkaRedisConfig, bullRedisConfig, moreRedisOpts);
+      await init(config as any, orkaOptions);
+      const bull = getBull();
+      const expectedRedisOpts = {
+        host: 'bull',
+        port: '6379',
+        tls: { ca: ['bull-ca'], cert: 'bull-cert', key: 'bull-key' },
+        enableReadyCheck: true
       };
       bull.redisOpts.should.be.eql(expectedRedisOpts);
     });


### PR DESCRIPTION
This PR:
* Allows passing more options to Bull's redis connection (ie `enableReadyCheck`)
* Allows to customise the queue name case in custom metrics reported to newrelic (in order not to break existing dashboards/alerts if the naming was not camelCase)