### PR TITLE
[ENG-18] Add request context middleware to orka

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,9 +175,9 @@ npm i bull
 ```
 Bull uses `Redis` as a backend, in order to configure redis with bull, you have 2 options:
 1. Reuse the connection properties of your existing redis configuration ( `config.redis...` )
-2. Configure bull specific connection options like so: 
+2. Configure bull specific connection options like so:
 ```js
-{ 
+{
   bull: {
     redis: {
       url: '',
@@ -187,12 +187,12 @@ Bull uses `Redis` as a backend, in order to configure redis with bull, you have 
         key: ''
       }
     }
-  } 
-}   
+  }
+}
 ```
 To configure your application queues, use the following configuration:
 ```js
-{ 
+{
   bull: {
     queue: {
       options: {
@@ -213,3 +213,117 @@ To configure your application queues, use the following configuration:
 }
 ```
 The `options` in both cases can be any of [JobOptions](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/b4330da8ebd802197809ca6f349961a506679d3d/types/bull/index.d.ts#L369).
+
+## Request Context
+Orka by default exposes a Request Context to the app.
+
+It can be used for setting/getting variables that can be accessible in every code file (within the request's life). It uses nodeJS `async_hooks` to store this information.
+
+By default it appends `requestId` and `visitor` (if you have the option `config.visitor.orka` enabled) in the request context. The `requestId` is retrieved using the option `config.traceHeaderName`
+
+### Log Tracer
+If the Request Context is enabled, orka by default appends `requestId` and `visitor` to all the application logs automatically.
+
+
+### Configuration
+If you don't specify anything in your `config.requestContext` it defaults to:
+
+```js
+{
+  "requestContext": {
+    "logKeys": ["requestId", "visitor"]  // These are the keys that will be appended automatically to your logs
+  }
+}
+```
+
+If you want to override the configuration you can do easily do it:
+```js
+{
+  "requestContext": {
+    "logKeys": ["anotherKey"]
+  }
+}
+```
+
+If you want to disable request context, just pass:
+```js
+{
+  "requestContext": false
+}
+```
+
+### getRequestContext
+This method can be used to access the request context within your app.
+
+Returns:
+A Map<string, any> with the current request context
+
+e.g.
+```js
+import {getRequestContext} from '@workablehr/orka'
+```
+
+### Examples
+Using the request context on another file:
+
+```js
+// src/app.js
+builder({...})
+  .useDefaults()
+  .start()
+
+// src/services/a-service.js called after a HTTP call
+import {getRequestContext, getLogger} from '@workablehr/orka'
+
+export const method = async () => {
+  const ctx = getRequestContext();
+  const id = ctx.get('requestId');
+  // id = a-uid
+  getLogger('log').info('An informative log');
+  // Logs for json
+  // {
+  //   "timestamp":"2020-11-18T19:38:14.810Z",
+  //   "severity":"INFO",
+  //   "categoryName":"log",
+  //   "message":"An informative log",
+  //   "context":{
+  //     "requestId": "a-uid"
+  //   }
+  // }
+  // Logs for console
+  // ["2020-11-18T19:38:14.810Z"] [INFO] [log] [a-uid] An informative log
+};
+```
+
+Example of setting a variable in request context:
+
+```js
+// src/app.js
+builder({...})
+  .useDefaults()
+  .start()
+
+// src/config/routes.js
+import {getRequestContext} from '@workablehr/orka'
+
+module.exports = {
+  get: {
+    '/test': async (ctx, next) => {
+      await service.method();
+    },
+  },
+  prefix: {
+    '/foo': async (ctx, next) => {
+      getRequestContext().set('var', 'test');
+      await next();
+    }
+  }
+};
+
+// src/services/a-service.js called after a HTTP call
+import {getRequestContext} from '@workablehr/orka'
+
+export const method = async () => {
+  console.log(getRequestContext().get('var')); // prints test
+};
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -774,9 +774,9 @@
       }
     },
     "@types/node": {
-      "version": "11.15.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.15.2.tgz",
-      "integrity": "sha512-BqCU9uIFkUH9Sgo2uLYbmIiFB1T+VBiM8AI/El3LIAI5KzwtckeSG+3WOYZr9aMoX4UIvRFBWBeSaOu6hFue2Q==",
+      "version": "12.19.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.5.tgz",
+      "integrity": "sha512-Wgdl27uw/jUYUFyajUGKSjDNGxmJrZi9sjeG6UJImgUtKbJoO9aldx+1XODN1EpNDX9DirvbvHHmTsNlb8GwMA==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -1299,7 +1299,7 @@
     },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "resolved": "https://workable.jfrog.io/workable/api/npm/npm/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "buffer-from": {
@@ -2050,7 +2050,7 @@
     },
     "ent": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
+      "resolved": "https://workable.jfrog.io/workable/api/npm/npm/ent/-/ent-2.2.0.tgz",
       "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0="
     },
     "error-ex": {
@@ -2304,7 +2304,7 @@
     },
     "findit2": {
       "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/findit2/-/findit2-2.2.3.tgz",
+      "resolved": "https://workable.jfrog.io/workable/api/npm/npm/findit2/-/findit2-2.2.3.tgz",
       "integrity": "sha1-WKRmaX34piBc39vzlVNri9d3pfY="
     },
     "flat": {
@@ -6126,7 +6126,7 @@
     },
     "stubs": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
+      "resolved": "https://workable.jfrog.io/workable/api/npm/npm/stubs/-/stubs-3.0.0.tgz",
       "integrity": "sha1-6NK6H6nJBXAwPAMLaQD31fiavls="
     },
     "superagent": {
@@ -6334,7 +6334,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://workable.jfrog.io/workable/api/npm/npm/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "tmp": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@types/lodash": "^4.14.147",
     "@types/mocha": "^5.2.6",
     "@types/mongoose": "^5.5.31",
-    "@types/node": "^11.15.2",
+    "@types/node": "^12.19.5",
     "@types/redis": "^2.8.14",
     "@types/sinon": "^7.5.0",
     "bull": "^3.16.0",

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -4,6 +4,10 @@ import _defaults from './default-options';
 import * as lodash from 'lodash';
 import { getLogger } from './initializers/log4js';
 import orkaType from './orka-builder';
+import { AsyncLocalStorage } from 'async_hooks';
+
+const als = new AsyncLocalStorage<Map<string, any>>();
+export const getRequestContext = () => als.getStore();
 
 export default (defaults: Partial<OrkaOptions> = _defaults) => {
   const options: Partial<OrkaOptions> = lodash.cloneDeep(lodash.defaultsDeep({}, defaults, _defaults));
@@ -50,5 +54,5 @@ export default (defaults: Partial<OrkaOptions> = _defaults) => {
   const errorHandler = require('./initializers/koa/error-handler').default;
 
   const OrkaBuilder: typeof orkaType = require('./orka-builder').default;
-  return new OrkaBuilder(options, config, errorHandler);
+  return new OrkaBuilder(options, config, errorHandler, als);
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import Orka from './orka';
 import * as middlewares from './middlewares';
 
-export { default as builder } from './builder';
+export { default as builder, getRequestContext } from './builder';
 export { getLogger } from './initializers/log4js';
 export * from './initializers/kafka';
 export const orka = Orka;

--- a/src/initializers/koa/add-request-context.ts
+++ b/src/initializers/koa/add-request-context.ts
@@ -1,0 +1,14 @@
+import { AsyncLocalStorage } from 'async_hooks';
+import { Context, Middleware } from 'koa';
+
+export default function(als: AsyncLocalStorage<Map<string, any>>): Middleware {
+  return async (ctx: Context, next: () => Promise<void>) => {
+    const store = new Map<string, any>();
+    return als.run(store, () => {
+      if (ctx.state.requestId) {
+        store.set('requestId', ctx.state.requestId);
+      }
+      return next();
+    });
+  };
+}

--- a/src/initializers/koa/add-visitor-id.ts
+++ b/src/initializers/koa/add-visitor-id.ts
@@ -1,5 +1,6 @@
 import { Context, Middleware } from 'koa';
 import { getLogger } from 'log4js';
+import { getRequestContext } from '../../builder';
 
 const logger = getLogger('orka.visitor');
 
@@ -14,8 +15,9 @@ export default function(config): Middleware {
     try {
       const { cookie_id: visitor } = decode(cookie);
       ctx.state.visitor = visitor;
+      getRequestContext()?.set('visitor', ctx.state.visitor);
     } catch (e) {
-       logger.error(`Failed to parse cookie ${config.visitor.cookie} = ${cookie}`, e);
+      logger.error(`Failed to parse cookie ${config.visitor.cookie} = ${cookie}`, e);
     } finally {
       return await next();
     }

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2018",
+    "target": "es2019",
     "module": "commonjs",
     "noImplicitAny": false,
     "removeComments": true,
@@ -14,7 +14,8 @@
     "baseUrl": ".",
     "paths": {
       "orka/*": ["./*"]
-    }
+    },
+    "lib": ["es2019"]
   },
   "filesGlob": ["./*.ts"]
 }

--- a/test/orka-builder.test.ts
+++ b/test/orka-builder.test.ts
@@ -1,6 +1,7 @@
 import OrkaBuilder from '../src/orka-builder';
 import * as sinon from 'sinon';
 import * as redis from '../src/initializers/redis';
+import * as rc from '../src/initializers/koa/add-request-context';
 
 const sandbox = sinon.createSandbox();
 
@@ -12,7 +13,7 @@ describe('orka-builder', function() {
   it('calls redis', async function() {
     const config = {};
     const stub = sandbox.stub(redis, 'createRedisConnection');
-    const builder = new OrkaBuilder({}, { redis: config }, () => undefined);
+    const builder = new OrkaBuilder({}, { redis: config }, () => undefined, sandbox.stub());
     builder.withRedis();
     await builder.initTasks();
     stub.args.should.eql([[config]]);

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2018",
+    "target": "es2019",
     "module": "commonjs",
     "rootDir": "../",
     "sourceRoot": "../",
@@ -8,8 +8,9 @@
     "sourceMap": true,
     "paths": {
       "orka/*": ["./src/*"]
-    }
+    },
+    "lib": ["es2019"]
   },
   "include": ["**/*.tsx", "**/*.ts", "**/*.d.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules"],
 }


### PR DESCRIPTION
## Summary
This is the first PR of adding a `Request Context` to orka.

Example for how async_hooks work: https://www.icloud.com/keynote/0uwcgADQfQRGhUDkzAZ4SMd7A#AsyncLocalStorage

This change requires NodeJS: 12.17.0+, 13.14.0+, or 14.0.0+

Another PR will follow:
* Reading this context and exposing those variables to the log4js appenders
* Adding an exampe in the `/examples` folder