### PR TITLE
[ENG-18] Use RequestContext to log4js appenders

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -82,8 +82,8 @@
       "name": "Mocha Tests",
       "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
       "args": [
-        "--opts",
-        "${workspaceFolder}/test/mocha.opts"
+        "--timeout",
+        "9999999"
       ],
       "internalConsoleOptions": "openOnSessionStart",
       "env": {

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+*       @echetzakis @jgerbe @klesgidis @kzacharakis @nikosd23 @nikostoulas @stavros-wb
+

--- a/README.md
+++ b/README.md
@@ -231,24 +231,9 @@ If you don't specify anything in your `config.requestContext` it defaults to:
 ```js
 {
   "requestContext": {
+    "enabled": true
     "logKeys": ["requestId", "visitor"]  // These are the keys that will be appended automatically to your logs
   }
-}
-```
-
-If you want to override the configuration you can do easily do it:
-```js
-{
-  "requestContext": {
-    "logKeys": ["anotherKey"]
-  }
-}
-```
-
-If you want to disable request context, just pass:
-```js
-{
-  "requestContext": false
 }
 ```
 

--- a/examples/request-context-example/app.js
+++ b/examples/request-context-example/app.js
@@ -1,0 +1,31 @@
+const { orka, getRequestContext } = require('../../build');
+
+const w = orka({
+  beforeMiddleware: () => [
+    async function defaultMiddleware(ctx, next) {
+      ctx.body = 'default body';
+      await next();
+    }
+  ],
+  afterMiddleware: () => [
+    async (ctx, next) => {
+      const store = getRequestContext();
+      if (store) {
+        store.set('afterMiddleware', 'orka');
+      }
+      await next();
+    }
+  ],
+  diamorphosis: { configFolder: './examples/request-context-example' },
+  routesPath: './examples/request-context-example/routes.js',
+  beforeStart: () => {
+    const config = require('./config');
+    console.log(`Going to start env: ${config.nodeEnv}`);
+  }
+});
+
+if (!module.parent) {
+  w.start();
+}
+
+module.exports = w;

--- a/examples/request-context-example/config.js
+++ b/examples/request-context-example/config.js
@@ -1,0 +1,19 @@
+module.exports = {
+  nodeEnv: 'demo',
+  log: {
+    json: true
+  },
+  app: {
+    name: 'foo'
+  },
+  cors: {
+    publicPrefixes: ['/api/allowAll']
+  },
+  riviere: {
+    bodyKeysRegex: '.*'
+  },
+  requestContext: {
+    logKeys: ['requestId', 'query', 'afterMiddleware']
+  },
+  port: 2121
+};

--- a/examples/request-context-example/routes.js
+++ b/examples/request-context-example/routes.js
@@ -1,0 +1,28 @@
+const { getLogger, getRequestContext } = require('../../build');
+const { testMe } = require('./service');
+
+module.exports = {
+  get: {
+    '/log': async ctx => {
+      getLogger('log').info('A log in controller, before service call');
+      await testMe();
+      getLogger('log').info('A log in controller, after service call');
+      ctx.body = 'ok';
+      ctx.status = 200;
+    },
+    '/logWithAppendedRequestContextVar': async (ctx, next) => {
+      await testMe();
+      ctx.body = 'ok';
+      ctx.status = 200;
+    }
+  },
+  prefix: {
+    '/logWithAppendedRequestContextVar': async (ctx, next) => {
+      const store = getRequestContext();
+      if (store && ctx.query.q) {
+        store.set('query', ctx.query.q);
+      }
+      await next();
+    }
+  }
+};

--- a/examples/request-context-example/service.js
+++ b/examples/request-context-example/service.js
@@ -1,0 +1,10 @@
+const { getLogger } = require('../../build');
+
+const logger = getLogger('log');
+
+module.exports = {
+  testMe: async () => {
+    logger.info('A log in a service');
+    return 'foo';
+  }
+};

--- a/src/initializers/diamorphosis.ts
+++ b/src/initializers/diamorphosis.ts
@@ -19,7 +19,7 @@ export default (config, orkaOptions: Partial<OrkaOptions>) => {
   };
   config.printLogo = defaultTo(config.printLogo, true);
   config.log = {
-    pattern: '%[[%d] [%p] %c%] %m',
+    pattern: '%[[%d] [%p] %c%] %x{logTracer} %m',
     level: 'debug',
     console: '',
     json: false,
@@ -59,6 +59,11 @@ export default (config, orkaOptions: Partial<OrkaOptions>) => {
       ...config.kafka.producer
     };
   }
+  config.requestContext = {
+    enabled: true,
+    logKeys: ['requestId', 'visitor'],
+    ...config.requestContext
+  };
   diamorphosis(orkaOptions.diamorphosis);
   config.app.env = config.app.env || config.nodeEnv;
 

--- a/src/orka-builder.ts
+++ b/src/orka-builder.ts
@@ -65,7 +65,7 @@ export default class OrkaBuilder {
 
   useDefaults() {
     this.use(() => addRequestId(this.config));
-    if (this.config.requestContext) {
+    if (this.config.requestContext.enabled) {
       this.use(() => addRequestContext(this.als));
     }
     this.use(() => bodyParser(this.config.bodyParser));

--- a/test/examples/examples.test.ts
+++ b/test/examples/examples.test.ts
@@ -46,7 +46,7 @@ describe('examples', function() {
         delete require.cache[require.resolve('../../build/index.js')];
         if (setEnv) setEnv();
         server = require(serverPath);
-        server.start();
+        return server.start();
       });
 
       afterEach(function() {

--- a/test/examples/request-context-example.test.ts
+++ b/test/examples/request-context-example.test.ts
@@ -1,0 +1,79 @@
+import * as sinon from 'sinon';
+import * as supertest from 'supertest';
+
+const sandbox = sinon.createSandbox();
+
+describe('request-context', function() {
+  let server;
+  let clock;
+  let request;
+
+  before(function() {
+    process.env.LOG_LEVEL = 'info';
+    process.env.LOG_JSON = 'true';
+    delete process.env.NEW_RELIC_LICENSE_KEY;
+  });
+
+  after(function() {
+    process.env.LOG_LEVEL = 'fatal';
+    delete process.env.LOG_JSON;
+    if (server) server.stop();
+    clock.restore();
+  });
+
+  before(async function() {
+    const serverPath = '../../examples/request-context-example/app';
+    delete require.cache[require.resolve('../../build/builder.js')];
+    delete require.cache[require.resolve('../../build/index.js')];
+    delete require.cache[require.resolve('../../build/orka-builder.js')];
+    delete require.cache[require.resolve('../../build/orka.js')];
+    delete require.cache[require.resolve('../../build/initializers/koa/add-visitor-id.js')];
+    delete require.cache[require.resolve('../../build/initializers/log4js/index.js')];
+    delete require.cache[require.resolve('../../build/initializers/log4js/json-appender.js')];
+    delete require.cache[require.resolve(serverPath)];
+    server = require(serverPath);
+    await server.start();
+    request = supertest('localhost:2121');
+    clock = sinon.useFakeTimers(new Date('2019-01-01'));
+  });
+
+  afterEach(function() {
+    sandbox.restore();
+  });
+
+  const logEntry = (message, context) => [
+    JSON.stringify({
+      timestamp: '2019-01-01T00:00:00.000Z',
+      severity: 'INFO',
+      categoryName: 'log',
+      message,
+      context
+    })
+  ];
+
+  it('/log returns 200 and logs info with requestId', async function() {
+    const logSpy = sandbox.stub(console, 'log');
+    const response = await request
+      .get('/log')
+      .set('x-request-id', 'test-id')
+      .expect(200);
+    response.text.should.eql('ok');
+    logSpy.args.should.eql([
+      logEntry('A log in controller, before service call', { requestId: 'test-id', afterMiddleware: 'orka' }),
+      logEntry('A log in a service', { requestId: 'test-id', afterMiddleware: 'orka' }),
+      logEntry('A log in controller, after service call', { requestId: 'test-id', afterMiddleware: 'orka' })
+    ]);
+  });
+
+  it('/logWithAppendedRequestContextVar returns 200 and logs info with requestId and appended var', async function() {
+    const logSpy = sandbox.stub(console, 'log');
+    const response = await request
+      .get('/logWithAppendedRequestContextVar?q=testme')
+      .set('x-request-id', 'test-id')
+      .expect(200);
+    response.text.should.eql('ok');
+    logSpy.args.should.eql([
+      logEntry('A log in a service', { requestId: 'test-id', query: 'testme', afterMiddleware: 'orka' })
+    ]);
+  });
+});

--- a/test/orka-builder.test.ts
+++ b/test/orka-builder.test.ts
@@ -1,7 +1,6 @@
 import OrkaBuilder from '../src/orka-builder';
 import * as sinon from 'sinon';
 import * as redis from '../src/initializers/redis';
-import * as rc from '../src/initializers/koa/add-request-context';
 
 const sandbox = sinon.createSandbox();
 


### PR DESCRIPTION
## Summary
Uses request context and appends `requestContext.logKeys` to the log message.

It is working for both `console` and `json` logs.

PS 1 Another PR will follow for making `requestContext`'s usage, dependent on the NodeJS version you use

PS 2 Logs from careers with `x-request-id: kyriakos`
<img width="735" alt="Screenshot 2020-11-24 at 1 56 56 PM" src="https://user-images.githubusercontent.com/44189854/100092951-8864a480-2e5f-11eb-9b5a-98b55e34e8db.png">
