### PR TITLE
[ENG-40] Mitigates statSync error for typescript apps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@workablehr/orka",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workablehr/orka",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "",
   "main": "build/index.js",
   "scripts": {

--- a/src/middlewares/health.ts
+++ b/src/middlewares/health.ts
@@ -21,7 +21,7 @@ export default async function(ctx: Context, next: () => Promise<null>) {
     ctx.status = 200;
     ctx.body = {
       env: OrkaBuilder.INSTANCE.config.nodeEnv,
-      version: `v${process.env.npm_package_version}`
+      version: process.env.DD_VERSION || `v${process.env.npm_package_version}`
     };
   } else {
     ctx.status = 503;

--- a/src/middlewares/health.ts
+++ b/src/middlewares/health.ts
@@ -1,15 +1,22 @@
 import { Context } from 'koa';
 import { isHealthy } from '../initializers/rabbitmq';
 
+export enum ConnectionStates {
+  disconnected = 0,
+  connected = 1,
+  connecting = 2,
+  disconnecting = 3,
+  uninitialized = 99
+}
+
 export default async function(ctx: Context, next: () => Promise<null>) {
-  const mongoose = await import('mongoose');
   const { getConnection } = await import('../initializers/mongodb');
 
   // tslint:disable-next-line: no-empty
   const mongoConnection = getConnection(() => {});
   // tslint:disable-next-line: no-empty
   const isRabbitHealthy = isHealthy();
-  if ((!mongoConnection || mongoConnection.readyState === mongoose.Connection.STATES.connected) && isRabbitHealthy) {
+  if ((!mongoConnection || mongoConnection.readyState === ConnectionStates.connected) && isRabbitHealthy) {
     const OrkaBuilder = (await import('../orka-builder')).default;
     ctx.status = 200;
     ctx.body = {


### PR DESCRIPTION
## Summary
`tsconfig-paths` has probably an issue and doesn't cache some `require` functions when they're called inside another function. That causes [these errors](https://app.datadoghq.com/apm/resource/employeeportal-fs/fs.operation/2751b46978b3b4f9?end=1607328141432&env=officedroid&index=apm-search&paused=false&query=env%3Aofficedroid%20service%3Aemployeeportal-fs%20operation_name%3Afs.operation%20resource_name%3AstatSync&start=1607324541432) in DataDog.

This PR solve this by removing `mongoose` dependency from health middleware (we were just using the connection states) to mitigate this issue, until we find out and fix the actual reason that causes this issue

In addition, uses `DD_VERSION` if exists for application version. This will help us render the correct version on staging environments