### PR TITLE
Add github scripts for testing, releasing and publishing to npm

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,27 @@
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+name: Create Release
+
+jobs:
+  build:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          body: |
+            Changes in this Release
+          draft: false
+          prerelease: false

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,38 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
+
+name: Node.js Package
+
+on:
+  release:
+    types: 
+      - published
+      - created
+      - edited
+      - prereleased
+      - released
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - run: npm ci
+
+  publish-npm:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,12 +17,13 @@ jobs:
   build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     strategy:
       matrix:
         node-version: [12.x, 14.x]
         mongodb-version: [4.0]
-
+        rabbit-version: [5]
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -38,6 +39,11 @@ jobs:
         uses: supercharge/mongodb-github-action@1.3.0
         with:
           mongodb-version: ${{ matrix.mongodb-version }}
+
+      - name: Start Rabbit
+        uses: nijel/rabbitmq-action@v1.0.0
+          with:
+            rabbitmq version: ${{ matrix.rabbit-version }}
 
       # Runs a set of commands using the runners shell
       - name: Run a multi-line script

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,8 +42,8 @@ jobs:
 
       - name: Start Rabbit
         uses: nijel/rabbitmq-action@v1.0.0
-          with:
-            rabbitmq version: ${{ matrix.rabbit-version }}
+        with:
+          rabbitmq version: ${{ matrix.rabbit-version }}
 
       # Runs a set of commands using the runners shell
       - name: Run a multi-line script

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         node-version: [12.x, 14.x]
         mongodb-version: [4.0]
-        rabbit-version: [5]
+        rabbit-version: ['5']
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -40,7 +40,7 @@ jobs:
         with:
           mongodb-version: ${{ matrix.mongodb-version }}
 
-      - name: Start Rabbit
+      - name: Start RabbitMQ
         uses: nijel/rabbitmq-action@v1.0.0
         with:
           rabbitmq version: ${{ matrix.rabbit-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x]
         mongodb-version: [4.0]
 
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - name Checkout code
+      - name: Checkout code
         uses: actions/checkout@v2
 
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,11 +21,23 @@ jobs:
     strategy:
       matrix:
         node-version: [10.x, 12.x, 14.x]
+        mongodb-version: [4.0]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - name Checkout code
+        uses: actions/checkout@v2
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Start MongoDB
+        uses: supercharge/mongodb-github-action@1.3.0
+        with:
+          mongodb-version: ${{ matrix.mongodb-version }}
 
       # Runs a set of commands using the runners shell
       - name: Run a multi-line script

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the main branch
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x]
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      # Runs a set of commands using the runners shell
+      - name: Run a multi-line script
+        run: |
+          npm install
+          npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         node-version: [12.x, 14.x]
         mongodb-version: [4.0]
-        rabbit-version: ['5']
+        rabbit-version: [3.8.4]
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-const regex = /^v(\d+)\.(\d+)\.(\d+)$/g;
+const regex = /^v(\d+)\.(\d+)\.(\d+)$/;
 
 export const alsSupported = () =>
   nodeVersionGreaterThanEqual('v12.17.0') ||
@@ -6,8 +6,12 @@ export const alsSupported = () =>
   nodeVersionGreaterThanEqual('v14.0.0');
 
 export const nodeVersionGreaterThanEqual = (requestedVersion: string, version = process.version) => {
-  const [major, minor, patch] = [...version.matchAll(regex)][0].slice(1).map((n: string) => parseInt(n, 10));
-  const [requestedMajor, requestedMinor, requestedPatch] = [...requestedVersion.matchAll(regex)][0]
+  const [major, minor, patch] = version
+    .match(regex)
+    .slice(1)
+    .map((n: string) => parseInt(n, 10));
+  const [requestedMajor, requestedMinor, requestedPatch] = requestedVersion
+    .match(regex)
     .slice(1)
     .map((n: string) => parseInt(n, 10));
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,13 +6,9 @@ export const alsSupported = () =>
   nodeVersionGreaterThanEqual('v14.0.0');
 
 export const nodeVersionGreaterThanEqual = (requestedVersion: string, version = process.version) => {
-  const [major, minor, patch] = version
+  const [, major, minor, patch] = version.match(regex).map((n: string) => parseInt(n, 10));
+  const [, requestedMajor, requestedMinor, requestedPatch] = requestedVersion
     .match(regex)
-    .slice(1)
-    .map((n: string) => parseInt(n, 10));
-  const [requestedMajor, requestedMinor, requestedPatch] = requestedVersion
-    .match(regex)
-    .slice(1)
     .map((n: string) => parseInt(n, 10));
 
   if (major > requestedMajor) return true;


### PR DESCRIPTION
Move unit testing to github (our plan now supports actions for open source projects)

Simplify creating a release. For those that have [admin](https://github.com/orgs/Workable/teams/node-js-admins) access the process will be as follows:
- `git checkout master && git pull`
- `npm version minor`
- `git push && git push --tags`
- wait for tests to pass and release to be automatically created
- Go to the release page and write a proper release description
- Wait for the job to publish orka to npm

For non-admins the tag creations should continue to happen through a pr that then is *merged* (not squashed) to master.