### PR TITLE
Pass the whole config to DD tracer

### DIFF
--- a/src/initializers/datadog/index.ts
+++ b/src/initializers/datadog/index.ts
@@ -6,7 +6,8 @@ export default config => {
   if (process.env.DD_SERVICE && process.env.DD_ENV) {
     tracer = requireInjected('dd-trace').init();
     tracer.use('koa', {
-      blacklist: config?.datadog?.blacklistedPaths
+      blacklist: config?.datadog?.blacklistedPaths,
+      ...config.datadog
     });
   }
 };


### PR DESCRIPTION
## Summary
Pass the whole object from config to datadog. 

We can use this to enable logging of specific headers in DD

e.g. 
```
{
    datadog: {
        headers: ['host']
    }
}
```

will log the host header to DD