### PR TITLE
Add datadog-match-routes middleware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1396,7 +1396,7 @@
     },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
-      "resolved": "https://workable.jfrog.io/workable/api/npm/npm/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "buffer-from": {
@@ -2304,7 +2304,7 @@
     },
     "ent": {
       "version": "2.2.0",
-      "resolved": "https://workable.jfrog.io/workable/api/npm/npm/ent/-/ent-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
       "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0="
     },
     "error-ex": {
@@ -2558,7 +2558,7 @@
     },
     "findit2": {
       "version": "2.2.3",
-      "resolved": "https://workable.jfrog.io/workable/api/npm/npm/findit2/-/findit2-2.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/findit2/-/findit2-2.2.3.tgz",
       "integrity": "sha1-WKRmaX34piBc39vzlVNri9d3pfY="
     },
     "flat": {
@@ -6708,7 +6708,7 @@
     },
     "stubs": {
       "version": "3.0.0",
-      "resolved": "https://workable.jfrog.io/workable/api/npm/npm/stubs/-/stubs-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
       "integrity": "sha1-6NK6H6nJBXAwPAMLaQD31fiavls="
     },
     "superagent": {
@@ -6925,7 +6925,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://workable.jfrog.io/workable/api/npm/npm/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "tmp": {

--- a/src/middlewares/datadog-match-routes.ts
+++ b/src/middlewares/datadog-match-routes.ts
@@ -1,0 +1,12 @@
+import { Context } from 'koa';
+
+export default async function matchedRoute(ctx: Context, next: () => Promise<void>) {
+  if (ctx._matchedRoute) {
+    const ddSpan = ctx.req?._datadog?.span;
+    if (ddSpan) {
+      ddSpan.setTag('resource.name', `${ctx.request.method} ${ctx._matchedRoute}`);
+      ddSpan.setTag('matchedRoute', ctx._matchedRoute);
+    }
+  }
+  await next();
+}

--- a/src/middlewares/index.ts
+++ b/src/middlewares/index.ts
@@ -1,5 +1,6 @@
 import health from './health';
 import metrics from './metrics';
+import datadogMatchRoutes from './datadog-match-routes';
 import { validateBody, validateQueryString } from './validate-params';
 
-export { health, validateBody, validateQueryString, metrics };
+export { health, validateBody, validateQueryString, metrics, datadogMatchRoutes };

--- a/src/typings/koa.d.ts
+++ b/src/typings/koa.d.ts
@@ -1,0 +1,7 @@
+import { IncomingMessage } from 'http';
+
+declare module 'koa' {
+  interface Context {
+    req: IncomingMessage & { _datadog: { span: { setTag: (name: string, value: string) => void } } };
+  }
+}

--- a/test/middlewares/datadog-match-routes.test.ts
+++ b/test/middlewares/datadog-match-routes.test.ts
@@ -1,0 +1,44 @@
+/// <reference types="../../src/typings/koa" />
+import * as sinon from 'sinon';
+import { Context } from 'koa';
+import datadogMatchRoutes from '../../src/middlewares/datadog-match-routes';
+
+const sandbox = sinon.createSandbox();
+describe('Datadog match routes middleware', function () {
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  describe('Dadatog not enabled', function () {
+    it('runs next', async function () {
+      const ctx = {} as Context;
+      const next = sandbox.stub();
+      await datadogMatchRoutes(ctx, next);
+      next.called.should.be.true();
+      ctx.should.eql({});
+    });
+  });
+
+  describe('Datadog enabled', function () {
+    it('calls ddSpan', async function () {
+      const stub = sandbox.stub();
+      const ctx = ({
+        req: { _datadog: { span: { setTag: stub } } },
+        request: { method: 'GET' },
+        _matchedRoute: '/api/foo/bar'
+      } as unknown) as Context;
+      const next = sandbox.stub();
+      await datadogMatchRoutes(ctx, next);
+      ctx.should.eql({
+        req: { _datadog: { span: { setTag: stub } } },
+        request: { method: 'GET' },
+        _matchedRoute: '/api/foo/bar'
+      });
+      next.called.should.be.true();
+      stub.args.should.eql([
+        ['resource.name', 'GET /api/foo/bar'],
+        ['matchedRoute', '/api/foo/bar']
+      ]);
+    });
+  });
+});

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -12,5 +12,5 @@
     "lib": ["es2019", "es2020.string"]
   },
   "include": ["**/*.tsx", "**/*.ts", "**/*.d.ts"],
-  "exclude": ["node_modules"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Add middleware to log proper route names to DD.
Usage:

//routes.js
```js

const { middlewares } = require('@workablehr/orka');

module.exports = {
  ...,
  prefix:{
  '/':middlewares.datadogMatchRoutes
}
```
