### PR TITLE
Rename group ids

### DIFF
--- a/examples/kafka-example/config.js
+++ b/examples/kafka-example/config.js
@@ -7,7 +7,8 @@ module.exports = {
     json: true
   },
   kafka: {
-    groupId: 'orka.example.consumer',
+    groupId: 'orka.example.pigasos',
+    oldGroupId: 'orka.example.consumer',
     clientId: 'orka.example.producer',
     brokers: ['localhost:9092'],
     certificates: {
@@ -25,7 +26,7 @@ module.exports = {
     consumer: {
       topics: {
         name: 'orka.example.test',
-        batchSize: 10
+        groupId: 'orka.example.consumer'
       }
     },
     producer: {

--- a/examples/kafka-example/routes.js
+++ b/examples/kafka-example/routes.js
@@ -8,8 +8,8 @@ module.exports = {
       const config = require('./config');
       const kafka = getKafka();
       const topic = config.kafka.consumer.topics.name;
-      const batchSize = config.kafka.consumer.topics.batchSize;
-      new KafkaHandler(kafka, { topic, logger: getLogger('test'), batchSize });
+      const groupId = config.kafka.consumer.topics.groupId;
+      new KafkaHandler(kafka, { topic, logger: getLogger('test'), fromBeginning: true, consumerOptions: { groupId } });
     },
     '/write': async (ctx, next) => {
       const config = require('./config');


### PR DESCRIPTION
**TLDR**: Kafka.js does not allow multiple consumers with the same groupId. Apps that have > 1 topics currently with node-rdkafka will have to rename all (but one) groupIds. 

This pr introduces a convenient way to do this in production:

```js
await getKafka().renameGroupId([
  { groupId: config.kafka.groupId, topic, oldGroupId: config.kafka.oldGroupId },
  { groupId: config.kafka.groupId2, topic, oldGroupId: config.kafka.oldGroupId2 },
  ...rest
]);
```


 In kafka.js: consumers with the same groupId must subscribe to exactly the same topics. See [RECEIVED_UNSUBSCRIBED_TOPICS](https://kafka.js.org/docs/faq#is-kafkajs-used-in-production)
I have also asked kafkajs [slack channel](https://kafkajs.slack.com/archives/CF6RFPF6K/p1611943584031700) and the suggested way forward is to rename our groupIds to sth unique.

The way we previously used orka all consumers of an app had the same groupId with no way to configure it. 
There is an easy way now to configure different groupIds per consumer:

```js
new KafkaHandler(
  kafka,
  { topic, consumerOptions: { groupId: config.kafka.groupId + '.' + options.topic } }
);
```


