### PR TITLE
Do not set offsets to -1

### DIFF
--- a/src/initializers/kafka/kafka.ts
+++ b/src/initializers/kafka/kafka.ts
@@ -2,7 +2,7 @@ import { getLogger } from '../log4js';
 import requireInjected from '../../require-injected';
 import { KafkaConfig } from '../../typings/kafka';
 import type * as KafkajsType from 'kafkajs';
-import { flatten } from 'lodash';
+import { flatten, isEmpty } from 'lodash';
 import * as uuid from 'uuid';
 
 const { Kafka }: typeof KafkajsType = requireInjected('kafkajs');
@@ -81,8 +81,9 @@ export default class OrkaKafka {
           if (offsets.every(({ offset }) => offset === '-1')) {
             // groupId is not configured
             const oldOffsets = await admin.fetchOffsets({ groupId: oldGroupId, topic, resolveOffsets: false });
-            await admin.setOffsets({ groupId, topic, partitions: oldOffsets });
-            return { groupId, renamedFrom: oldGroupId, oldOffsets };
+            const knownOffsets = oldOffsets?.filter(o => o.offset !== '-1');
+            if (!isEmpty(knownOffsets)) await admin.setOffsets({ groupId, topic, partitions: knownOffsets });
+            return { groupId, renamedFrom: oldGroupId, oldOffsets: knownOffsets };
           } else {
             return { groupId, renamedFrom: oldGroupId, alreadyDeclared: true };
           }

--- a/src/initializers/kafka/kafka.ts
+++ b/src/initializers/kafka/kafka.ts
@@ -83,9 +83,9 @@ export default class OrkaKafka {
             const oldOffsets = await admin.fetchOffsets({ groupId: oldGroupId, topic, resolveOffsets: false });
             const knownOffsets = oldOffsets?.filter(o => o.offset !== '-1');
             if (!isEmpty(knownOffsets)) await admin.setOffsets({ groupId, topic, partitions: knownOffsets });
-            return { groupId, renamedFrom: oldGroupId, oldOffsets: knownOffsets };
+            return { groupId, renamedFrom: oldGroupId, topic, oldOffsets: knownOffsets };
           } else {
-            return { groupId, renamedFrom: oldGroupId, alreadyDeclared: true };
+            return { groupId, renamedFrom: oldGroupId, topic, alreadyDeclared: true };
           }
         })
         .map(promise =>

--- a/test/initializers/kafka/kafka.test.ts
+++ b/test/initializers/kafka/kafka.test.ts
@@ -347,9 +347,14 @@ describe('kafka class', () => {
         [{ groupId: 'newGroupId', partitions: [{ offset: '3', partition: 0 }], topic: 'topic' }]
       ]);
       response.should.eql([
-        { groupId: 'newGroupId', oldOffsets: [{ offset: '3', partition: 0 }], renamedFrom: 'oldGroupId' },
-        { alreadyDeclared: true, groupId: 'newGroupId2', renamedFrom: 'oldGroupId2' },
-        { groupId: 'newGroupId3', oldOffsets: [], renamedFrom: 'oldGroupId3' }
+        {
+          groupId: 'newGroupId',
+          oldOffsets: [{ offset: '3', partition: 0 }],
+          topic: 'topic',
+          renamedFrom: 'oldGroupId'
+        },
+        { alreadyDeclared: true, groupId: 'newGroupId2', topic: 'topic2', renamedFrom: 'oldGroupId2' },
+        { groupId: 'newGroupId3', oldOffsets: [], topic: 'topic3', renamedFrom: 'oldGroupId3' }
       ]);
     });
   });


### PR DESCRIPTION
When creating offsets for a new groupId,topic pair from an old groupId,topic pair we were setting offset to -1 for partitions that had no message consumed. This might cause issues to some tools so a better approach is to completely ignore such offsets.