### PR TITLE
[ENG-74] [PROD-1676] Add runWithContext function

### DIFF
--- a/docs/request-context.md
+++ b/docs/request-context.md
@@ -51,7 +51,7 @@ e.g.
 import { getRequestContext } from '@workablehr/orka';
 ```
 
-### Examples
+#### Usage
 
 Using the request context on another file:
 
@@ -114,5 +114,39 @@ import {getRequestContext} from '@workablehr/orka'
 
 export const method = async () => {
   console.log(getRequestContext().get('var')); // prints test
+};
+```
+
+### runWithContext
+
+This method can be used to execute a callback within a context.
+
+e.g.
+
+```js
+import { runWithContext } from '@workablehr/orka';
+```
+
+#### Usage
+
+Using the request context on another file:
+
+```js
+
+// src/handler.js
+import {runWithContext} from '@workablehr/orka'
+
+module.exports = {
+  test: () => {
+    const store = Map([['requestId', 'trace-id']])
+    return runWithContext(store, service.method, 'arg1', 'arg2');
+  }
+};
+
+// src/services/a-service.js called after a HTTP call
+import {getRequestContext} from '@workablehr/orka'
+
+export const method = async (arg1, arg2) => {
+  console.log(getRequestContext().get('requestId')); // trace-id
 };
 ```

--- a/examples/run-with-context-example/app.js
+++ b/examples/run-with-context-example/app.js
@@ -1,0 +1,19 @@
+const { orka, runWithContext } = require('../../build');
+const { testMe } = require('./service');
+
+const w = orka({
+  diamorphosis: { configFolder: './examples/run-with-context-example' }
+});
+
+const testFunction = () => {
+  return runWithContext(new Map([['requestId', 'trace-id']]), testMe, 'argument');
+};
+
+if (!module.parent) {
+  w.initTasks().then(testFunction);
+}
+
+module.exports = {
+  default: w,
+  testFunction
+};

--- a/examples/run-with-context-example/config.js
+++ b/examples/run-with-context-example/config.js
@@ -1,0 +1,19 @@
+module.exports = {
+  nodeEnv: 'demo',
+  log: {
+    json: true
+  },
+  app: {
+    name: 'foo'
+  },
+  cors: {
+    publicPrefixes: ['/api/allowAll']
+  },
+  riviere: {
+    bodyKeysRegex: '.*'
+  },
+  requestContext: {
+    logKeys: ['requestId', 'query', 'afterMiddleware']
+  },
+  port: 2121
+};

--- a/examples/run-with-context-example/service.js
+++ b/examples/run-with-context-example/service.js
@@ -1,0 +1,10 @@
+const { getLogger } = require('../../build');
+
+const logger = getLogger('log');
+
+module.exports = {
+  testMe: async arg => {
+    logger.info('A log in a service', arg);
+    return 'foo';
+  }
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import Orka from './orka';
 import * as middlewares from './middlewares';
 import * as helpers from './helpers';
 
-export { default as builder, getRequestContext } from './builder';
+export { default as builder, getRequestContext, runWithContext } from './builder';
 export { getLogger } from './initializers/log4js';
 export * from './initializers/kafka';
 export const orka = Orka;

--- a/src/initializers/log4js/index.ts
+++ b/src/initializers/log4js/index.ts
@@ -9,11 +9,11 @@ let tmp = name => {
   return logger;
 };
 
-export let getLogger = name => {
-  if (loggers[name]) return loggers[name];
+export let getLogger = (name: string) => {
+  if (loggers[name]) return loggers[name] as Log4js.Logger;
 
   loggers[name] = tmp(name);
-  return loggers[name];
+  return loggers[name] as Log4js.Logger;
 };
 const loggers = {};
 

--- a/test/examples/run-with-context-example.test.ts
+++ b/test/examples/run-with-context-example.test.ts
@@ -1,0 +1,64 @@
+import * as sinon from 'sinon';
+import { runWithContext } from '../../build';
+import { alsSupported } from '../../src/utils';
+
+const sandbox = sinon.createSandbox();
+
+describe('request-context', function () {
+  let server;
+  let testFunction;
+  let clock;
+  const hasALS = alsSupported();
+
+  before(function () {
+    process.env.LOG_LEVEL = 'info';
+    process.env.LOG_JSON = 'true';
+    delete process.env.NEW_RELIC_LICENSE_KEY;
+  });
+
+  after(function () {
+    process.env.LOG_LEVEL = 'fatal';
+    delete process.env.LOG_JSON;
+    clock.restore();
+  });
+
+  before(async function () {
+    const serverPath = '../../examples/run-with-context-example/app';
+    delete require.cache[require.resolve('../../build/builder.js')];
+    delete require.cache[require.resolve('../../build/index.js')];
+    delete require.cache[require.resolve('../../build/orka-builder.js')];
+    delete require.cache[require.resolve('../../build/orka.js')];
+    delete require.cache[require.resolve('../../build/initializers/koa/add-visitor-id.js')];
+    delete require.cache[require.resolve('../../build/initializers/log4js/index.js')];
+    delete require.cache[require.resolve('../../build/initializers/log4js/json-appender.js')];
+    delete require.cache[require.resolve(serverPath)];
+    const mod = require(serverPath);
+    server = mod.default;
+    testFunction = mod.testFunction;
+    clock = sinon.useFakeTimers(new Date('2019-01-01'));
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  const logEntry = (message, context) => [
+    JSON.stringify({
+      timestamp: '2019-01-01T00:00:00.000Z',
+      severity: 'INFO',
+      categoryName: 'initializing.log',
+      message,
+      context: hasALS ? context : {}
+    })
+  ];
+
+  it('it appends requestId to logs if runWithContext', async function () {
+    const logSpy = sandbox.stub(console, 'log');
+    await server
+      .initTasks()
+      .then(testFunction);
+    logSpy.args.should.eql([
+      logEntry('A log in a service argument', { requestId: 'trace-id' }),
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
* Exports typings to orka's getLogger
* Creates a new function called `runWithContext` to be used by workers, handlers etc. This function can be used to execute a callback inside it that will have an available request context. (see usage in the documentation)