### PR TITLE
[ENG-75] [PROD-1677] Add runWithContext to BaseKafkaHandler & BaseQueueHandler

### DIFF
--- a/src/initializers/diamorphosis.ts
+++ b/src/initializers/diamorphosis.ts
@@ -84,7 +84,7 @@ export default (config, orkaOptions: Partial<OrkaOptions>) => {
 
   config.requestContext = {
     enabled: alsSupported(),
-    logKeys: ['requestId', 'visitor'],
+    logKeys: ['requestId', 'visitor', 'correlationId'],
     ...config.requestContext
   };
   diamorphosis(orkaOptions.diamorphosis);

--- a/test/initializers/kafka/base-kafka-handler.test.ts
+++ b/test/initializers/kafka/base-kafka-handler.test.ts
@@ -4,8 +4,13 @@ import Kafka from '../../../src/initializers/kafka/kafka';
 import BaseKafkaHandler from '../../../src/initializers/kafka/base-kafka-handler';
 
 const sandbox = sinon.createSandbox();
+const logger = {
+  trace: () => null,
+  debug: () => null,
+  info: () => null
+} as any;
 
-describe.only('base kafka handler class', async () => {
+describe('base kafka handler class', async () => {
   let handleStub, consumeStub, runStub, subscribeStub;
 
   class TestKafkaHandler extends BaseKafkaHandler<any, any> {
@@ -41,7 +46,6 @@ describe.only('base kafka handler class', async () => {
 
   it('should call consumer with multiple topics', async () => {
     const createConsumer = sandbox.stub(Kafka.prototype, 'createConsumer').resolves(consumeStub);
-    const logSpy = sandbox.stub(console, 'log');
     const kafka = new Kafka({ groupId: 'groupId', clientId: 'clientId', brokers: [] } as any);
     const consumerOptions = { groupId: 'newGroup' };
     const runOptions = { partitionsConsumedConcurrently: 5 };
@@ -56,7 +60,6 @@ describe.only('base kafka handler class', async () => {
     should.equal(undefined, handler.fromBeginning);
     consumeStub.run.args.should.containDeep([[runOptions]]);
     handleStub.args.should.containDeep([[{ value: { msg: 'msg' }, headers: { key: 'key' } }]]);
-    logSpy.args.should.containDeep([['tes']]);
   });
 
   context('with autoOffsetReset latest', function () {

--- a/test/initializers/kafka/base-kafka-handler.test.ts
+++ b/test/initializers/kafka/base-kafka-handler.test.ts
@@ -4,13 +4,8 @@ import Kafka from '../../../src/initializers/kafka/kafka';
 import BaseKafkaHandler from '../../../src/initializers/kafka/base-kafka-handler';
 
 const sandbox = sinon.createSandbox();
-const logger = {
-  trace: () => null,
-  debug: () => null,
-  info: () => null
-} as any;
 
-describe('base kafka handler class', async () => {
+describe.only('base kafka handler class', async () => {
   let handleStub, consumeStub, runStub, subscribeStub;
 
   class TestKafkaHandler extends BaseKafkaHandler<any, any> {
@@ -29,6 +24,7 @@ describe('base kafka handler class', async () => {
         async ({ eachMessage: fn }) =>
           await fn({
             message: {
+              key: Buffer.from('key'),
               value: Buffer.from('{"msg":"msg"}'),
               headers: { key: Buffer.from('key') }
             },
@@ -45,6 +41,7 @@ describe('base kafka handler class', async () => {
 
   it('should call consumer with multiple topics', async () => {
     const createConsumer = sandbox.stub(Kafka.prototype, 'createConsumer').resolves(consumeStub);
+    const logSpy = sandbox.stub(console, 'log');
     const kafka = new Kafka({ groupId: 'groupId', clientId: 'clientId', brokers: [] } as any);
     const consumerOptions = { groupId: 'newGroup' };
     const runOptions = { partitionsConsumedConcurrently: 5 };
@@ -59,6 +56,7 @@ describe('base kafka handler class', async () => {
     should.equal(undefined, handler.fromBeginning);
     consumeStub.run.args.should.containDeep([[runOptions]]);
     handleStub.args.should.containDeep([[{ value: { msg: 'msg' }, headers: { key: 'key' } }]]);
+    logSpy.args.should.containDeep([['tes']]);
   });
 
   context('with autoOffsetReset latest', function () {

--- a/test/initializers/rabbitmq/index.test.ts
+++ b/test/initializers/rabbitmq/index.test.ts
@@ -4,7 +4,7 @@ import 'should';
 
 const sandbox = sinon.createSandbox();
 
-describe('Test rabbitmq connection', function() {
+describe('Test rabbitmq connection', function () {
   let config;
   const orkaOptions = {
     appName: 'test'
@@ -13,7 +13,7 @@ describe('Test rabbitmq connection', function() {
   let onStub: sinon.SinonSpy;
   let getRabbit;
 
-  beforeEach(async function() {
+  beforeEach(async function () {
     config = {
       queue: {
         prefetch: 100,
@@ -28,12 +28,15 @@ describe('Test rabbitmq connection', function() {
     stub = sandbox.stub().returns({
       on: onStub
     });
-    mock('rabbit-queue', { Rabbit: stub });
+    mock('rabbit-queue', {
+      Rabbit: stub,
+      BaseQueueHandler: { prototype: { tryHandle: { call: sandbox.stub() } } }
+    });
     delete require.cache[require.resolve('../../../src/initializers/rabbitmq')];
     ({ default: getRabbit } = await import('../../../src/initializers/rabbitmq'));
   });
 
-  afterEach(function() {
+  afterEach(function () {
     sandbox.restore();
     mock.stopAll();
   });


### PR DESCRIPTION
## Summary
If AsyncLocalStorage is supported, orka uses `runWithContext` in `BaseKafkaHandler` and `BaseQueueHandler`. By doing this `correlationId` will be logged with every log statement inside the handler.

Examples:
BaseKafkaHandler:
<img width="1024" alt="Screenshot 2021-03-24 at 1 55 42 PM" src="https://user-images.githubusercontent.com/44189854/112363852-9d065b80-8cde-11eb-9684-95d41a5347bd.png">

BaseQueueHandler:
<img width="876" alt="Screenshot 2021-03-24 at 8 22 53 PM" src="https://user-images.githubusercontent.com/44189854/112363953-b909fd00-8cde-11eb-9d37-cdbe2023b5be.png">
