### PR TITLE
Rename default trace header name from x-request-id to x-orka-request-id

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ config = {
     publicPrefixes: ['/publicEndpoints/foo/bar'] // ctx.path prefixes that will return access-control-allow-origin: *
     …
   },
-  traceHeaderName: 'X-Request-Id', // for logging in http requests
+  traceHeaderName: 'X-Orka-Request-Id', // for logging in http requests
   visitor: { orka: true, cookie : 'wmc' }, // for adding visitor id in ctx.state
   headersRegex: '^X-.*', // for logging headers in http requests
   blacklistedErrorCodes: [404] // will not send to honeybadger requests with this status

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -110,7 +110,7 @@ config.queue.prefetch value will be 30 from .env
 
 By default orka loads your config file with some default values and some empty keys.
 Those keys are needed in order for you to be able to overwrite them with env variables.
-However if not overwritten they are not used. Eg. if QUEUE_URL is not set rabbitMQ will 
+However if not overwritten they are not used. Eg. if QUEUE_URL is not set rabbitMQ will
 never be initialized.
 
 You can find the default values below:
@@ -163,7 +163,7 @@ You can find the default values below:
   },
   "port": 3000,
   "allowedOrigins": ["localhost", "lvh.me"],
-  "traceHeaderName": "X-Request-Id",
+  "traceHeaderName": "X-Orka-Request-Id",
   "blacklistedErrorCodes": [404],
   "riviere": {
     "enabled": true,

--- a/src/initializers/diamorphosis.ts
+++ b/src/initializers/diamorphosis.ts
@@ -58,7 +58,7 @@ export default (config, orkaOptions: Partial<OrkaOptions>) => {
   };
   config.port = config.port || 3000;
   config.allowedOrigins = config.allowedOrigins || ['localhost', 'lvh.me'];
-  config.traceHeaderName = config.traceHeaderName || 'X-Request-Id';
+  config.traceHeaderName = config.traceHeaderName || 'X-Orka-Request-Id';
   config.blacklistedErrorCodes = config.blacklistedErrorCodes || [404];
   config.riviere = {
     enabled: true,

--- a/test/examples/json-appender.test.ts
+++ b/test/examples/json-appender.test.ts
@@ -38,7 +38,7 @@ describe('json-appender', function() {
     const logSpy = sandbox.stub(console, 'log');
     const { text } = await (supertest('localhost:3000') as any)
       .get('/log?')
-      .set('x-request-id', 'test-id')
+      .set('x-orka-request-id', 'test-id')
       .expect(200);
     text.should.eql('logged');
     logSpy.args.should.eql([
@@ -61,7 +61,7 @@ describe('json-appender', function() {
     const logSpy = sandbox.stub(console, 'log');
     const { text } = await (supertest('localhost:3000') as any)
       .get('/logError')
-      .set('x-request-id', 'test-id')
+      .set('x-orka-request-id', 'test-id')
       .expect(505);
     text.should.eql('default body');
     const cleanStack = msg => {

--- a/test/examples/request-context-example.test.ts
+++ b/test/examples/request-context-example.test.ts
@@ -57,7 +57,7 @@ describe('request-context', function() {
     const logSpy = sandbox.stub(console, 'log');
     const response = await request
       .get('/log')
-      .set('x-request-id', 'test-id')
+      .set('x-orka-request-id', 'test-id')
       .expect(200);
     response.text.should.eql('ok');
     logSpy.args.should.eql([
@@ -71,7 +71,7 @@ describe('request-context', function() {
     const logSpy = sandbox.stub(console, 'log');
     const response = await request
       .get('/logWithAppendedRequestContextVar?q=testme')
-      .set('x-request-id', 'test-id')
+      .set('x-orka-request-id', 'test-id')
       .expect(200);
     response.text.should.eql('ok');
     logSpy.args.should.eql([

--- a/test/initializers/koa/error-handler.test.ts
+++ b/test/initializers/koa/error-handler.test.ts
@@ -37,7 +37,7 @@ describe('error-handler', function() {
     const loggerStub = sandbox.stub(log4js.getLogger('orka.errorHandler').constructor.prototype, 'error');
     const { body } = await (supertest('localhost:3000') as any)
       .get('/')
-      .set('X-Request-Id', '1')
+      .set('X-Orka-Request-Id', '1')
       .expect(500);
     body.should.eql({
       action: '/',


### PR DESCRIPTION
`X-Request-Id` is overridden  by k8s