### PR TITLE
Add limiter configuring to Bull queues [PROD-1977]

### DIFF
--- a/docs/integrations/bull.md
+++ b/docs/integrations/bull.md
@@ -50,6 +50,10 @@ To configure your application queues, use the following configuration:
         {
           name: 'queue_two',
           options: { delay: 15000 } // This is applied to queue_two
+        },
+         {
+          name: 'rate_limited',
+          limiter: { max:  10, duration: 1000 } // rate limited queue
         }
       ]
     }
@@ -59,3 +63,4 @@ To configure your application queues, use the following configuration:
 
 The `options` in both cases can be any of [JobOptions](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/b4330da8ebd802197809ca6f349961a506679d3d/types/bull/index.d.ts#L369).
 
+The `limiter` can be configured according to [RateLimiter](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/4ca04a72c942754a0368a343a7a7e64a9215da93/types/bull/index.d.ts#L42).


### PR DESCRIPTION
### Description
In the scope of [PROD-1977](https://workable.atlassian.net/browse/PROD-1977) we needed a distributed rate-limiting mechanism which is already offered by [Bull](https://optimalbits.github.io/bull/#:~:text=Rate%20Limiter,1.000%20jobs%20per%205%20seconds.) 
but we did not expose this  queue option via Orka.

This PR allows to configure queues with a `limiter` parameter and set properties according to the [RateLimiter](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/4ca04a72c942754a0368a343a7a7e64a9215da93/types/bull/index.d.ts#L42) interface.

#### Related Jira:
* [PROD-1977](https://workable.atlassian.net/browse/PROD-1977)