### PR TITLE
Improve docs for 'runWithContext'

### DIFF
--- a/docs/integrations/kafka.md
+++ b/docs/integrations/kafka.md
@@ -113,6 +113,9 @@ module.exports = class KafkaHandler extends BaseKafkaHandler {
 // [123] Consuming message
 // [123] Var: orka
 ```
+
+Note: In the above example only `correlationId` is logged by default. If you want to have the `test-variable` automatically logged on each log entry, you need to include it on your configuration `requestContext.logKeys`. For more, see the [Log Tracer](https://workable.github.io/orka/request-context.html#log-tracer) docs.
+
 #### app.js
 ```js
 //app.js

--- a/docs/integrations/kafka.md
+++ b/docs/integrations/kafka.md
@@ -74,7 +74,6 @@ module.exports = {
 
 ### Consuming messages
 
-
 #### app/services/kafka/handler.js
 ```js
 // app/services/kafka/handler.js
@@ -89,6 +88,31 @@ module.exports = class KafkaHandler extends BaseKafkaHandler {
 };
 ```
 
+#### RequestContext
+When you use `BaseKafkaHandler`, orka by default runs the message handling inside `runWithContext` function and appends the `key` of the message in the context with name `correlationId`.
+
+That means that every log of your consumer will contain the `key` of the message and that you can also add any variable you want in the context.
+
+Example:
+```js
+const { BaseKafkaHandler, getRequestContext } = require('@workablehr/orka');
+
+async function handler(val) {
+  logger.info('Var: ', getRequestContext().get('test-variable'))
+}
+
+module.exports = class KafkaHandler extends BaseKafkaHandler {
+  async handle(message) {
+    getRequestContext().set('test-variable', 'orka');
+    logger.info('Consuming message');
+    await handler(message.value);
+  }
+};
+
+// In the above example if we receive a message with key=123, it will log:
+// [123] Consuming message
+// [123] Var: orka
+```
 #### app.js
 ```js
 //app.js

--- a/docs/integrations/rabbitmq.md
+++ b/docs/integrations/rabbitmq.md
@@ -98,3 +98,5 @@ class ExampleHandler extends BaseQueueHandler {
 // [xxx] hello
 // [xxx] Var: orka
 ```
+
+Note: In the above example only `correlationId` is logged by default. If you want to have the `test-var` automatically logged on each log entry, you need to include it on your configuration `requestContext.logKeys`. For more, see the [Log Tracer](https://workable.github.io/orka/request-context.html#log-tracer) docs.

--- a/docs/integrations/rabbitmq.md
+++ b/docs/integrations/rabbitmq.md
@@ -24,6 +24,8 @@ module.exports = {
 };
 ```
 
+## BaseQueueHandler
+
 ```js
 // app/services/queue-handlers/example-handler.js
 const { BaseQueueHandler } = require('rabbit-queue');
@@ -58,4 +60,41 @@ orka({
     getRabbit().bindToTopic('example_queue', '*.example_queue');
   }
 });
+```
+
+## RequestContext
+When you use `BaseQueueHandler`, orka by default runs the message handling inside `runWithContext` function and appends the `correlationId` of the message in the context.
+
+That means that every log of your consumer will contain the `correlationId` of the message and that you can also add any variable you want in the context.
+
+Example:
+```js
+const { BaseQueueHandler } = require('rabbit-queue');
+const { getRabbit, getRequestContext } = require('@workablehr/orka');
+
+async function handler(m) {
+  logger.info('Var: ', getRequestContext().get('test-var'));
+}
+
+class ExampleHandler extends BaseQueueHandler {
+  constructor(queueName, logEnabled = true) {
+    const config = require('./config');
+    super(queueName, getRabbit(), {
+      logEnabled,
+      retries: 3, // 3 retries
+      retryDelay: 1000 // in ms
+    });
+  }
+
+  async handle(message) {
+    getRequestContext().set('test-var', 'orka');
+    logger.info(message);
+    await handler(message);
+  }
+
+}
+
+// In the above example if we receive a message with correlationId=xxx, and message="hello" it will log:
+// [xxx] hello
+// [xxx] Var: orka
 ```

--- a/docs/request-context.md
+++ b/docs/request-context.md
@@ -23,7 +23,7 @@ By default it appends `requestId` and `visitor` (if you have the option `config.
 
 ### Log Tracer
 
-If the Request Context is enabled, orka by default appends `requestId` and `visitor` to all the application logs automatically.
+If the Request Context is enabled, orka by default appends `requestId`, `correlationId` and `visitor` to all the application logs automatically.
 
 ### Configuration
 
@@ -33,7 +33,7 @@ If you don't specify anything in your `config.requestContext` it defaults to:
 {
   "requestContext": {
     "enabled": true
-    "logKeys": ["requestId", "visitor"]  // These are the keys that will be appended automatically to your logs
+    "logKeys": ["requestId", "visitor", "correlationId"]  // These are the keys that will be appended automatically to your logs
   }
 }
 ```


### PR DESCRIPTION
## Summary
Improves logs on how to use `getRequestContext` inside RabbitMQ handlers & Kafka consumers