### PR TITLE
Extend BaseHandler to support HB and orka's metrics by default

### DIFF
--- a/test/initializers/rabbitmq/index.test.ts
+++ b/test/initializers/rabbitmq/index.test.ts
@@ -125,8 +125,8 @@ describe('Test rabbitmq connection', function () {
     });
 
     it('getTime as a bigint from logMetrics', function () {
-      sandbox.stub(logMetrics, 'start').returns(1n);
-      queueHandler.getTime().should.eql(1n);
+      sandbox.stub(logMetrics, 'start').returns(1 as any);
+      queueHandler.getTime().should.eql(1);
     });
 
     it('logTime from logMetrics', function () {

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2019",
     "module": "commonjs",
     "rootDir": "../",
     "sourceRoot": "../",


### PR DESCRIPTION
rabbit-queue-updates