### PR TITLE
Provide an easy way through config to controll wether to use ssl or not: (useSsl) by default true.

### DIFF
--- a/__snapshots__/diamorphosis.test.ts.js
+++ b/__snapshots__/diamorphosis.test.ts.js
@@ -1,0 +1,1213 @@
+exports['Diamorphosis Test should set json/console loggingvariables when nothing is set config should be console:true, json:false, styles:[] 1'] = {
+  "nodeEnv": "development",
+  "app": {
+    "env": "development"
+  },
+  "clouddebugger": false,
+  "honeybadger": {
+    "apiKey": "",
+    "developmentEnvironments": [
+      "development",
+      "test"
+    ]
+  },
+  "newRelic": {
+    "appName": ""
+  },
+  "datadog": {
+    "blacklistedPaths": [
+      "/health",
+      "/metrics"
+    ]
+  },
+  "prometheus": {
+    "enabled": false,
+    "gatewayUrl": "",
+    "timeSummary": {
+      "enabled": true,
+      "labels": [
+        "flow",
+        "flowType"
+      ],
+      "type": "external",
+      "name": "flow_duration_seconds",
+      "help": "Flow duration in seconds",
+      "ageBuckets": 10,
+      "maxAgeSeconds": 60
+    },
+    "eventSummary": {
+      "enabled": true,
+      "labels": [
+        "event",
+        "eventType"
+      ],
+      "type": "external",
+      "name": "events",
+      "help": "Custom events, eg: event occurences, event lengths",
+      "ageBuckets": 10,
+      "maxAgeSeconds": 60
+    }
+  },
+  "printLogo": true,
+  "log": {
+    "pattern": "%[[%d] [%p] %c%] %x{logTracer} %m",
+    "level": "debug",
+    "console": true,
+    "json": false
+  },
+  "port": 3000,
+  "allowedOrigins": [
+    "localhost",
+    "lvh.me"
+  ],
+  "traceHeaderName": "X-Orka-Request-Id",
+  "blacklistedErrorCodes": [
+    404
+  ],
+  "riviere": {
+    "enabled": true,
+    "inbound": {
+      "request": {
+        "enabled": false
+      }
+    },
+    "outbound": {
+      "blacklistedPathRegex": {},
+      "request": {
+        "enabled": false
+      }
+    },
+    "color": true,
+    "styles": [],
+    "headersRegex": "^X-.*"
+  },
+  "healthCheck": {
+    "kafka": false,
+    "redis": false
+  },
+  "visitor": {
+    "cookie": ""
+  },
+  "kafka": {
+    "brokers": [],
+    "groupId": "",
+    "clientId": "",
+    "ssl": true,
+    "log": {
+      "level": "info"
+    },
+    "certificates": {
+      "key": "",
+      "cert": "",
+      "ca": [],
+      "rejectUnauthorized": false
+    },
+    "sasl": {
+      "mechanism": "",
+      "username": "",
+      "password": ""
+    },
+    "producer": {
+      "brokers": [],
+      "ssl": true,
+      "certificates": {
+        "key": "",
+        "cert": "",
+        "ca": [],
+        "rejectUnauthorized": false
+      },
+      "sasl": {
+        "mechanism": "",
+        "username": "",
+        "password": ""
+      }
+    }
+  },
+  "queue": {
+    "url": "",
+    "prefetch": 1,
+    "connectDelay": 5000,
+    "options": {
+      "scheduledPublish": true
+    }
+  },
+  "mongodb": {
+    "url": "",
+    "options": {
+      "useNewUrlParser": true,
+      "useCreateIndex": true,
+      "useFindAndModify": false,
+      "useUnifiedTopology": false
+    }
+  },
+  "redis": {
+    "url": "",
+    "options": {
+      "tls": {
+        "ca": "",
+        "cert": "",
+        "key": ""
+      }
+    }
+  },
+  "postgres": {
+    "url": "",
+    "poolSize": 50,
+    "useSsl": true,
+    "sslConfig": {
+      "rejectUnauthorized": false
+    }
+  },
+  "requestContext": {
+    "enabled": true,
+    "logKeys": [
+      "requestId",
+      "visitor",
+      "correlationId"
+    ]
+  }
+}
+
+exports['Diamorphosis Test should set json/console loggingvariables when console:not set, json:true, styles:[] shoud be console:false, json:true, styles:["json"] 1'] = {
+  "log": {
+    "pattern": "%[[%d] [%p] %c%] %x{logTracer} %m",
+    "level": "debug",
+    "console": false,
+    "json": true
+  },
+  "nodeEnv": "development",
+  "app": {
+    "env": "development"
+  },
+  "clouddebugger": false,
+  "honeybadger": {
+    "apiKey": "",
+    "developmentEnvironments": [
+      "development",
+      "test"
+    ]
+  },
+  "newRelic": {
+    "appName": ""
+  },
+  "datadog": {
+    "blacklistedPaths": [
+      "/health",
+      "/metrics"
+    ]
+  },
+  "prometheus": {
+    "enabled": false,
+    "gatewayUrl": "",
+    "timeSummary": {
+      "enabled": true,
+      "labels": [
+        "flow",
+        "flowType"
+      ],
+      "type": "external",
+      "name": "flow_duration_seconds",
+      "help": "Flow duration in seconds",
+      "ageBuckets": 10,
+      "maxAgeSeconds": 60
+    },
+    "eventSummary": {
+      "enabled": true,
+      "labels": [
+        "event",
+        "eventType"
+      ],
+      "type": "external",
+      "name": "events",
+      "help": "Custom events, eg: event occurences, event lengths",
+      "ageBuckets": 10,
+      "maxAgeSeconds": 60
+    }
+  },
+  "printLogo": true,
+  "port": 3000,
+  "allowedOrigins": [
+    "localhost",
+    "lvh.me"
+  ],
+  "traceHeaderName": "X-Orka-Request-Id",
+  "blacklistedErrorCodes": [
+    404
+  ],
+  "riviere": {
+    "enabled": true,
+    "inbound": {
+      "request": {
+        "enabled": false
+      }
+    },
+    "outbound": {
+      "blacklistedPathRegex": {},
+      "request": {
+        "enabled": false
+      }
+    },
+    "color": true,
+    "styles": [
+      "json"
+    ],
+    "headersRegex": "^X-.*"
+  },
+  "healthCheck": {
+    "kafka": false,
+    "redis": false
+  },
+  "visitor": {
+    "cookie": ""
+  },
+  "kafka": {
+    "brokers": [],
+    "groupId": "",
+    "clientId": "",
+    "ssl": true,
+    "log": {
+      "level": "info"
+    },
+    "certificates": {
+      "key": "",
+      "cert": "",
+      "ca": [],
+      "rejectUnauthorized": false
+    },
+    "sasl": {
+      "mechanism": "",
+      "username": "",
+      "password": ""
+    },
+    "producer": {
+      "brokers": [],
+      "ssl": true,
+      "certificates": {
+        "key": "",
+        "cert": "",
+        "ca": [],
+        "rejectUnauthorized": false
+      },
+      "sasl": {
+        "mechanism": "",
+        "username": "",
+        "password": ""
+      }
+    }
+  },
+  "queue": {
+    "url": "",
+    "prefetch": 1,
+    "connectDelay": 5000,
+    "options": {
+      "scheduledPublish": true
+    }
+  },
+  "mongodb": {
+    "url": "",
+    "options": {
+      "useNewUrlParser": true,
+      "useCreateIndex": true,
+      "useFindAndModify": false,
+      "useUnifiedTopology": false
+    }
+  },
+  "redis": {
+    "url": "",
+    "options": {
+      "tls": {
+        "ca": "",
+        "cert": "",
+        "key": ""
+      }
+    }
+  },
+  "postgres": {
+    "url": "",
+    "poolSize": 50,
+    "useSsl": true,
+    "sslConfig": {
+      "rejectUnauthorized": false
+    }
+  },
+  "requestContext": {
+    "enabled": true,
+    "logKeys": [
+      "requestId",
+      "visitor",
+      "correlationId"
+    ]
+  }
+}
+
+exports['Diamorphosis Test should set json/console loggingvariables when console:true, json:true, styles:[] shoud be console:true, json:true, styles:["json"] 1'] = {
+  "log": {
+    "pattern": "%[[%d] [%p] %c%] %x{logTracer} %m",
+    "level": "debug",
+    "console": true,
+    "json": true
+  },
+  "nodeEnv": "development",
+  "app": {
+    "env": "development"
+  },
+  "clouddebugger": false,
+  "honeybadger": {
+    "apiKey": "",
+    "developmentEnvironments": [
+      "development",
+      "test"
+    ]
+  },
+  "newRelic": {
+    "appName": ""
+  },
+  "datadog": {
+    "blacklistedPaths": [
+      "/health",
+      "/metrics"
+    ]
+  },
+  "prometheus": {
+    "enabled": false,
+    "gatewayUrl": "",
+    "timeSummary": {
+      "enabled": true,
+      "labels": [
+        "flow",
+        "flowType"
+      ],
+      "type": "external",
+      "name": "flow_duration_seconds",
+      "help": "Flow duration in seconds",
+      "ageBuckets": 10,
+      "maxAgeSeconds": 60
+    },
+    "eventSummary": {
+      "enabled": true,
+      "labels": [
+        "event",
+        "eventType"
+      ],
+      "type": "external",
+      "name": "events",
+      "help": "Custom events, eg: event occurences, event lengths",
+      "ageBuckets": 10,
+      "maxAgeSeconds": 60
+    }
+  },
+  "printLogo": true,
+  "port": 3000,
+  "allowedOrigins": [
+    "localhost",
+    "lvh.me"
+  ],
+  "traceHeaderName": "X-Orka-Request-Id",
+  "blacklistedErrorCodes": [
+    404
+  ],
+  "riviere": {
+    "enabled": true,
+    "inbound": {
+      "request": {
+        "enabled": false
+      }
+    },
+    "outbound": {
+      "blacklistedPathRegex": {},
+      "request": {
+        "enabled": false
+      }
+    },
+    "color": true,
+    "styles": [
+      "json"
+    ],
+    "headersRegex": "^X-.*"
+  },
+  "healthCheck": {
+    "kafka": false,
+    "redis": false
+  },
+  "visitor": {
+    "cookie": ""
+  },
+  "kafka": {
+    "brokers": [],
+    "groupId": "",
+    "clientId": "",
+    "ssl": true,
+    "log": {
+      "level": "info"
+    },
+    "certificates": {
+      "key": "",
+      "cert": "",
+      "ca": [],
+      "rejectUnauthorized": false
+    },
+    "sasl": {
+      "mechanism": "",
+      "username": "",
+      "password": ""
+    },
+    "producer": {
+      "brokers": [],
+      "ssl": true,
+      "certificates": {
+        "key": "",
+        "cert": "",
+        "ca": [],
+        "rejectUnauthorized": false
+      },
+      "sasl": {
+        "mechanism": "",
+        "username": "",
+        "password": ""
+      }
+    }
+  },
+  "queue": {
+    "url": "",
+    "prefetch": 1,
+    "connectDelay": 5000,
+    "options": {
+      "scheduledPublish": true
+    }
+  },
+  "mongodb": {
+    "url": "",
+    "options": {
+      "useNewUrlParser": true,
+      "useCreateIndex": true,
+      "useFindAndModify": false,
+      "useUnifiedTopology": false
+    }
+  },
+  "redis": {
+    "url": "",
+    "options": {
+      "tls": {
+        "ca": "",
+        "cert": "",
+        "key": ""
+      }
+    }
+  },
+  "postgres": {
+    "url": "",
+    "poolSize": 50,
+    "useSsl": true,
+    "sslConfig": {
+      "rejectUnauthorized": false
+    }
+  },
+  "requestContext": {
+    "enabled": true,
+    "logKeys": [
+      "requestId",
+      "visitor",
+      "correlationId"
+    ]
+  }
+}
+
+exports['Diamorphosis Test should set json/console loggingvariables when console:false, json:true, styles:[] shoud be console:false, json:true, styles:["json"] 1'] = {
+  "log": {
+    "pattern": "%[[%d] [%p] %c%] %x{logTracer} %m",
+    "level": "debug",
+    "console": false,
+    "json": true
+  },
+  "nodeEnv": "development",
+  "app": {
+    "env": "development"
+  },
+  "clouddebugger": false,
+  "honeybadger": {
+    "apiKey": "",
+    "developmentEnvironments": [
+      "development",
+      "test"
+    ]
+  },
+  "newRelic": {
+    "appName": ""
+  },
+  "datadog": {
+    "blacklistedPaths": [
+      "/health",
+      "/metrics"
+    ]
+  },
+  "prometheus": {
+    "enabled": false,
+    "gatewayUrl": "",
+    "timeSummary": {
+      "enabled": true,
+      "labels": [
+        "flow",
+        "flowType"
+      ],
+      "type": "external",
+      "name": "flow_duration_seconds",
+      "help": "Flow duration in seconds",
+      "ageBuckets": 10,
+      "maxAgeSeconds": 60
+    },
+    "eventSummary": {
+      "enabled": true,
+      "labels": [
+        "event",
+        "eventType"
+      ],
+      "type": "external",
+      "name": "events",
+      "help": "Custom events, eg: event occurences, event lengths",
+      "ageBuckets": 10,
+      "maxAgeSeconds": 60
+    }
+  },
+  "printLogo": true,
+  "port": 3000,
+  "allowedOrigins": [
+    "localhost",
+    "lvh.me"
+  ],
+  "traceHeaderName": "X-Orka-Request-Id",
+  "blacklistedErrorCodes": [
+    404
+  ],
+  "riviere": {
+    "enabled": true,
+    "inbound": {
+      "request": {
+        "enabled": false
+      }
+    },
+    "outbound": {
+      "blacklistedPathRegex": {},
+      "request": {
+        "enabled": false
+      }
+    },
+    "color": true,
+    "styles": [
+      "json"
+    ],
+    "headersRegex": "^X-.*"
+  },
+  "healthCheck": {
+    "kafka": false,
+    "redis": false
+  },
+  "visitor": {
+    "cookie": ""
+  },
+  "kafka": {
+    "brokers": [],
+    "groupId": "",
+    "clientId": "",
+    "ssl": true,
+    "log": {
+      "level": "info"
+    },
+    "certificates": {
+      "key": "",
+      "cert": "",
+      "ca": [],
+      "rejectUnauthorized": false
+    },
+    "sasl": {
+      "mechanism": "",
+      "username": "",
+      "password": ""
+    },
+    "producer": {
+      "brokers": [],
+      "ssl": true,
+      "certificates": {
+        "key": "",
+        "cert": "",
+        "ca": [],
+        "rejectUnauthorized": false
+      },
+      "sasl": {
+        "mechanism": "",
+        "username": "",
+        "password": ""
+      }
+    }
+  },
+  "queue": {
+    "url": "",
+    "prefetch": 1,
+    "connectDelay": 5000,
+    "options": {
+      "scheduledPublish": true
+    }
+  },
+  "mongodb": {
+    "url": "",
+    "options": {
+      "useNewUrlParser": true,
+      "useCreateIndex": true,
+      "useFindAndModify": false,
+      "useUnifiedTopology": false
+    }
+  },
+  "redis": {
+    "url": "",
+    "options": {
+      "tls": {
+        "ca": "",
+        "cert": "",
+        "key": ""
+      }
+    }
+  },
+  "postgres": {
+    "url": "",
+    "poolSize": 50,
+    "useSsl": true,
+    "sslConfig": {
+      "rejectUnauthorized": false
+    }
+  },
+  "requestContext": {
+    "enabled": true,
+    "logKeys": [
+      "requestId",
+      "visitor",
+      "correlationId"
+    ]
+  }
+}
+
+exports['Diamorphosis Test should set json/console loggingvariables when console:not set, json:true, styles:["simple"] shoud be console:false, json:true, styles:["simple"] 1'] = {
+  "log": {
+    "pattern": "%[[%d] [%p] %c%] %x{logTracer} %m",
+    "level": "debug",
+    "console": false,
+    "json": true
+  },
+  "riviere": {
+    "enabled": true,
+    "inbound": {
+      "request": {
+        "enabled": false
+      }
+    },
+    "outbound": {
+      "blacklistedPathRegex": {},
+      "request": {
+        "enabled": false
+      }
+    },
+    "color": true,
+    "styles": [
+      "simple"
+    ],
+    "headersRegex": "^X-.*"
+  },
+  "nodeEnv": "development",
+  "app": {
+    "env": "development"
+  },
+  "clouddebugger": false,
+  "honeybadger": {
+    "apiKey": "",
+    "developmentEnvironments": [
+      "development",
+      "test"
+    ]
+  },
+  "newRelic": {
+    "appName": ""
+  },
+  "datadog": {
+    "blacklistedPaths": [
+      "/health",
+      "/metrics"
+    ]
+  },
+  "prometheus": {
+    "enabled": false,
+    "gatewayUrl": "",
+    "timeSummary": {
+      "enabled": true,
+      "labels": [
+        "flow",
+        "flowType"
+      ],
+      "type": "external",
+      "name": "flow_duration_seconds",
+      "help": "Flow duration in seconds",
+      "ageBuckets": 10,
+      "maxAgeSeconds": 60
+    },
+    "eventSummary": {
+      "enabled": true,
+      "labels": [
+        "event",
+        "eventType"
+      ],
+      "type": "external",
+      "name": "events",
+      "help": "Custom events, eg: event occurences, event lengths",
+      "ageBuckets": 10,
+      "maxAgeSeconds": 60
+    }
+  },
+  "printLogo": true,
+  "port": 3000,
+  "allowedOrigins": [
+    "localhost",
+    "lvh.me"
+  ],
+  "traceHeaderName": "X-Orka-Request-Id",
+  "blacklistedErrorCodes": [
+    404
+  ],
+  "healthCheck": {
+    "kafka": false,
+    "redis": false
+  },
+  "visitor": {
+    "cookie": ""
+  },
+  "kafka": {
+    "brokers": [],
+    "groupId": "",
+    "clientId": "",
+    "ssl": true,
+    "log": {
+      "level": "info"
+    },
+    "certificates": {
+      "key": "",
+      "cert": "",
+      "ca": [],
+      "rejectUnauthorized": false
+    },
+    "sasl": {
+      "mechanism": "",
+      "username": "",
+      "password": ""
+    },
+    "producer": {
+      "brokers": [],
+      "ssl": true,
+      "certificates": {
+        "key": "",
+        "cert": "",
+        "ca": [],
+        "rejectUnauthorized": false
+      },
+      "sasl": {
+        "mechanism": "",
+        "username": "",
+        "password": ""
+      }
+    }
+  },
+  "queue": {
+    "url": "",
+    "prefetch": 1,
+    "connectDelay": 5000,
+    "options": {
+      "scheduledPublish": true
+    }
+  },
+  "mongodb": {
+    "url": "",
+    "options": {
+      "useNewUrlParser": true,
+      "useCreateIndex": true,
+      "useFindAndModify": false,
+      "useUnifiedTopology": false
+    }
+  },
+  "redis": {
+    "url": "",
+    "options": {
+      "tls": {
+        "ca": "",
+        "cert": "",
+        "key": ""
+      }
+    }
+  },
+  "postgres": {
+    "url": "",
+    "poolSize": 50,
+    "useSsl": true,
+    "sslConfig": {
+      "rejectUnauthorized": false
+    }
+  },
+  "requestContext": {
+    "enabled": true,
+    "logKeys": [
+      "requestId",
+      "visitor",
+      "correlationId"
+    ]
+  }
+}
+
+exports['Diamorphosis Test should set json/console loggingvariables when console:true set in process.env shoud be console:true, json:false, styles:[] 1'] = {
+  "nodeEnv": "testProcess",
+  "kafka": {
+    "brokers": [
+      "confluent"
+    ],
+    "groupId": "",
+    "clientId": "",
+    "ssl": true,
+    "certificates": {
+      "key": "key",
+      "cert": "cert",
+      "ca": "ca",
+      "rejectUnauthorized": false
+    },
+    "producer": {
+      "brokers": [
+        "confluent"
+      ],
+      "ssl": true,
+      "topics": {
+        "topic1": "topic1"
+      },
+      "certificates": {
+        "key": "key",
+        "cert": "cert",
+        "ca": "ca",
+        "rejectUnauthorized": false
+      },
+      "sasl": {
+        "mechanism": "",
+        "username": "",
+        "password": ""
+      }
+    },
+    "log": {
+      "level": "info"
+    },
+    "sasl": {
+      "mechanism": "",
+      "username": "",
+      "password": ""
+    }
+  },
+  "healthCheck": {
+    "kafka": true,
+    "redis": true
+  },
+  "visitor": {
+    "cookie": "cookie"
+  },
+  "app": {
+    "env": "testProcess"
+  },
+  "clouddebugger": false,
+  "honeybadger": {
+    "apiKey": "",
+    "developmentEnvironments": [
+      "development",
+      "test"
+    ]
+  },
+  "newRelic": {
+    "appName": ""
+  },
+  "datadog": {
+    "blacklistedPaths": [
+      "/health",
+      "/metrics"
+    ]
+  },
+  "prometheus": {
+    "enabled": false,
+    "gatewayUrl": "",
+    "timeSummary": {
+      "enabled": true,
+      "labels": [
+        "flow",
+        "flowType"
+      ],
+      "type": "external",
+      "name": "flow_duration_seconds",
+      "help": "Flow duration in seconds",
+      "ageBuckets": 10,
+      "maxAgeSeconds": 60
+    },
+    "eventSummary": {
+      "enabled": true,
+      "labels": [
+        "event",
+        "eventType"
+      ],
+      "type": "external",
+      "name": "events",
+      "help": "Custom events, eg: event occurences, event lengths",
+      "ageBuckets": 10,
+      "maxAgeSeconds": 60
+    }
+  },
+  "printLogo": false,
+  "log": {
+    "pattern": "%[[%d] [%p] %c%] %x{logTracer} %m",
+    "level": "fatal",
+    "console": true,
+    "json": false
+  },
+  "port": 3000,
+  "allowedOrigins": [
+    "localhost",
+    "lvh.me"
+  ],
+  "traceHeaderName": "X-Orka-Request-Id",
+  "blacklistedErrorCodes": [
+    404
+  ],
+  "riviere": {
+    "enabled": false,
+    "inbound": {
+      "request": {
+        "enabled": false
+      }
+    },
+    "outbound": {
+      "blacklistedPathRegex": {},
+      "request": {
+        "enabled": false
+      }
+    },
+    "color": true,
+    "styles": [],
+    "headersRegex": "^X-.*"
+  },
+  "queue": {
+    "url": "",
+    "prefetch": 1,
+    "connectDelay": 5000,
+    "options": {
+      "scheduledPublish": true
+    }
+  },
+  "mongodb": {
+    "url": "",
+    "options": {
+      "useNewUrlParser": true,
+      "useCreateIndex": true,
+      "useFindAndModify": false,
+      "useUnifiedTopology": false
+    }
+  },
+  "redis": {
+    "url": "",
+    "options": {
+      "tls": {
+        "ca": "",
+        "cert": "",
+        "key": ""
+      }
+    }
+  },
+  "postgres": {
+    "url": "",
+    "poolSize": 50,
+    "useSsl": true,
+    "sslConfig": {
+      "rejectUnauthorized": false
+    }
+  },
+  "requestContext": {
+    "enabled": true,
+    "logKeys": [
+      "requestId",
+      "visitor",
+      "correlationId"
+    ]
+  }
+}
+
+exports['Diamorphosis Test should set json/console loggingvariables when console:true, json:true set in process.env shoud be console:true, json:false, styles:[] 1'] = {
+  "nodeEnv": "testProcess",
+  "kafka": {
+    "brokers": [
+      "confluent"
+    ],
+    "groupId": "",
+    "clientId": "",
+    "ssl": true,
+    "certificates": {
+      "key": "key",
+      "cert": "cert",
+      "ca": "ca",
+      "rejectUnauthorized": false
+    },
+    "producer": {
+      "brokers": [
+        "confluent"
+      ],
+      "ssl": true,
+      "topics": {
+        "topic1": "topic1"
+      },
+      "certificates": {
+        "key": "key",
+        "cert": "cert",
+        "ca": "ca",
+        "rejectUnauthorized": false
+      },
+      "sasl": {
+        "mechanism": "",
+        "username": "",
+        "password": ""
+      }
+    },
+    "log": {
+      "level": "info"
+    },
+    "sasl": {
+      "mechanism": "",
+      "username": "",
+      "password": ""
+    }
+  },
+  "healthCheck": {
+    "kafka": true,
+    "redis": true
+  },
+  "visitor": {
+    "cookie": "cookie"
+  },
+  "app": {
+    "env": "testProcess"
+  },
+  "clouddebugger": false,
+  "honeybadger": {
+    "apiKey": "",
+    "developmentEnvironments": [
+      "development",
+      "test"
+    ]
+  },
+  "newRelic": {
+    "appName": ""
+  },
+  "datadog": {
+    "blacklistedPaths": [
+      "/health",
+      "/metrics"
+    ]
+  },
+  "prometheus": {
+    "enabled": false,
+    "gatewayUrl": "",
+    "timeSummary": {
+      "enabled": true,
+      "labels": [
+        "flow",
+        "flowType"
+      ],
+      "type": "external",
+      "name": "flow_duration_seconds",
+      "help": "Flow duration in seconds",
+      "ageBuckets": 10,
+      "maxAgeSeconds": 60
+    },
+    "eventSummary": {
+      "enabled": true,
+      "labels": [
+        "event",
+        "eventType"
+      ],
+      "type": "external",
+      "name": "events",
+      "help": "Custom events, eg: event occurences, event lengths",
+      "ageBuckets": 10,
+      "maxAgeSeconds": 60
+    }
+  },
+  "printLogo": false,
+  "log": {
+    "pattern": "%[[%d] [%p] %c%] %x{logTracer} %m",
+    "level": "fatal",
+    "console": true,
+    "json": true
+  },
+  "port": 3000,
+  "allowedOrigins": [
+    "localhost",
+    "lvh.me"
+  ],
+  "traceHeaderName": "X-Orka-Request-Id",
+  "blacklistedErrorCodes": [
+    404
+  ],
+  "riviere": {
+    "enabled": false,
+    "inbound": {
+      "request": {
+        "enabled": false
+      }
+    },
+    "outbound": {
+      "blacklistedPathRegex": {},
+      "request": {
+        "enabled": false
+      }
+    },
+    "color": true,
+    "styles": [
+      "json"
+    ],
+    "headersRegex": "^X-.*"
+  },
+  "queue": {
+    "url": "",
+    "prefetch": 1,
+    "connectDelay": 5000,
+    "options": {
+      "scheduledPublish": true
+    }
+  },
+  "mongodb": {
+    "url": "",
+    "options": {
+      "useNewUrlParser": true,
+      "useCreateIndex": true,
+      "useFindAndModify": false,
+      "useUnifiedTopology": false
+    }
+  },
+  "redis": {
+    "url": "",
+    "options": {
+      "tls": {
+        "ca": "",
+        "cert": "",
+        "key": ""
+      }
+    }
+  },
+  "postgres": {
+    "url": "",
+    "poolSize": 50,
+    "useSsl": true,
+    "sslConfig": {
+      "rejectUnauthorized": false
+    }
+  },
+  "requestContext": {
+    "enabled": true,
+    "logKeys": [
+      "requestId",
+      "visitor",
+      "correlationId"
+    ]
+  }
+}

--- a/__snapshots__/diamorphosis.test.ts.js
+++ b/__snapshots__/diamorphosis.test.ts.js
@@ -155,7 +155,10 @@ exports['Diamorphosis Test should set json/console loggingvariables when nothing
     "poolSize": 50,
     "useSsl": true,
     "sslConfig": {
-      "rejectUnauthorized": false
+      "rejectUnauthorized": false,
+      "ca": "",
+      "cert": "",
+      "key": ""
     }
   },
   "requestContext": {
@@ -327,7 +330,10 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
     "poolSize": 50,
     "useSsl": true,
     "sslConfig": {
-      "rejectUnauthorized": false
+      "rejectUnauthorized": false,
+      "ca": "",
+      "cert": "",
+      "key": ""
     }
   },
   "requestContext": {
@@ -499,7 +505,10 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
     "poolSize": 50,
     "useSsl": true,
     "sslConfig": {
-      "rejectUnauthorized": false
+      "rejectUnauthorized": false,
+      "ca": "",
+      "cert": "",
+      "key": ""
     }
   },
   "requestContext": {
@@ -671,7 +680,10 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
     "poolSize": 50,
     "useSsl": true,
     "sslConfig": {
-      "rejectUnauthorized": false
+      "rejectUnauthorized": false,
+      "ca": "",
+      "cert": "",
+      "key": ""
     }
   },
   "requestContext": {
@@ -843,7 +855,10 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
     "poolSize": 50,
     "useSsl": true,
     "sslConfig": {
-      "rejectUnauthorized": false
+      "rejectUnauthorized": false,
+      "ca": "",
+      "cert": "",
+      "key": ""
     }
   },
   "requestContext": {
@@ -1020,7 +1035,10 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
     "poolSize": 50,
     "useSsl": true,
     "sslConfig": {
-      "rejectUnauthorized": false
+      "rejectUnauthorized": false,
+      "ca": "",
+      "cert": "",
+      "key": ""
     }
   },
   "requestContext": {
@@ -1199,7 +1217,10 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
     "poolSize": 50,
     "useSsl": true,
     "sslConfig": {
-      "rejectUnauthorized": false
+      "rejectUnauthorized": false,
+      "ca": "",
+      "cert": "",
+      "key": ""
     }
   },
   "requestContext": {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,13 +5,15 @@ nav_order: 2
 ---
 
 # Configuration
+
 {: .no_toc }
 
 ## Table of contents
+
 {: .no_toc .text-delta }
 
 1. TOC
-{:toc}
+   {:toc}
 
 ## Diamorphosis
 
@@ -90,7 +92,6 @@ There are 4 different levels where you can add configuration:
 Every value you have in config/config.js will be overwritten by values in config/env/{NODE_ENV}.js.
 If you are in development .env is also loaded into memory and overwrites any value.
 The most important precedence have actual environment variables.
-
 
 Priority with examples:
 
@@ -230,6 +231,16 @@ You can find the default values below:
       "useUnifiedTopology": false
     }
   },
+  "postgres": {
+    "url":"",
+    "useSsl": true,
+    "sslConfig": {
+      "rejectUnauthorized": false,
+        "ca": "",
+        "cert": "",
+        "key": ""
+    }
+  },
   "redis": {
     "url": "",
     "options": {
@@ -248,6 +259,7 @@ You can find the default values below:
 ```
 
 You can overwrite those values with various ways:
+
 - setting them in your config.js file
 - setting the corresponding env variable
 - setting the corresponding env variable in .env for development

--- a/docs/integrations/postgres.md
+++ b/docs/integrations/postgres.md
@@ -27,14 +27,14 @@ module.exports = {
 }
 ```
 
-If you need to support ssl
+If don't need to support ssl
 ```js
 //config/config.js
 
 module.exports = {
   postgres: {
     url: 'postgres://localhost:5432/orka_development',
-    sslConfig: {rejectUnauthorized: false}
+    useSsl: false
   }
 }
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -319,6 +319,16 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@bahmutov/data-driven": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@bahmutov/data-driven/-/data-driven-1.0.0.tgz",
+      "integrity": "sha512-YqW3hPS0RXriqjcCrLOTJj+LWe3c8JpwlL83k1ka1Q8U05ZjAKbGQZYeTzUd0NFEnnfPtsUiKGpFEBJG6kFuvg==",
+      "dev": true,
+      "requires": {
+        "check-more-types": "2.24.0",
+        "lazy-ass": "1.6.0"
+      }
+    },
     "@google-cloud/common": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-3.5.0.tgz",
@@ -1296,7 +1306,7 @@
     },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
-      "resolved": "https://workable.jfrog.io/workable/api/npm/npm/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "buffer-from": {
@@ -1433,6 +1443,12 @@
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
       }
+    },
+    "check-more-types": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
+      "integrity": "sha1-FCD/sQ/URNz8ebQ4kbv//TKoRgA=",
+      "dev": true
     },
     "chokidar": {
       "version": "3.4.2",
@@ -1611,6 +1627,12 @@
       "version": "2.20.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
       "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+      "dev": true
+    },
+    "common-tags": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
+      "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
       "dev": true
     },
     "commondir": {
@@ -2064,6 +2086,48 @@
         }
       }
     },
+    "disparity": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/disparity/-/disparity-3.0.0.tgz",
+      "integrity": "sha512-n94Rzbv2ambRaFzrnBf34IEiyOdIci7maRpMkoQWB6xFYGA7Nbs0Z5YQzMfTeyQeelv23nayqOcssBoc6rKrgw==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "diff": "^4.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
+        }
+      }
+    },
     "dotenv": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-2.0.0.tgz",
@@ -2149,7 +2213,7 @@
     },
     "ent": {
       "version": "2.2.0",
-      "resolved": "https://workable.jfrog.io/workable/api/npm/npm/ent/-/ent-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
       "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0="
     },
     "error-ex": {
@@ -2258,6 +2322,15 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
+    "escape-quotes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/escape-quotes/-/escape-quotes-1.0.2.tgz",
+      "integrity": "sha1-tIltSmz4LdWzP0m3E0CMY4D2zZc=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      }
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -2390,7 +2463,7 @@
     },
     "findit2": {
       "version": "2.2.3",
-      "resolved": "https://workable.jfrog.io/workable/api/npm/npm/findit2/-/findit2-2.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/findit2/-/findit2-2.2.3.tgz",
       "integrity": "sha1-WKRmaX34piBc39vzlVNri9d3pfY="
     },
     "flat": {
@@ -2405,6 +2478,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
       "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg=="
+    },
+    "folktale": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/folktale/-/folktale-2.3.2.tgz",
+      "integrity": "sha512-+8GbtQBwEqutP0v3uajDDoN64K2ehmHd0cjlghhxh0WpcfPzAIjPA03e1VvHlxL02FVGR0A6lwXsNQKn3H1RNQ==",
+      "dev": true
     },
     "follow-redirects": {
       "version": "1.13.3",
@@ -2782,6 +2861,12 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
+    "has-only": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/has-only/-/has-only-1.1.1.tgz",
+      "integrity": "sha512-3GuFy9rDw0xvovCHb4SOKiRImbZ+a8boFBUyGNRPVd2mRyQOzYdau5G9nodUXC1ZKYN59hrHFkW1lgBQscYfTg==",
+      "dev": true
+    },
     "has-symbols": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
@@ -3079,6 +3164,15 @@
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
       "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
       "dev": true
+    },
+    "is-ci": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+      "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+      "dev": true,
+      "requires": {
+        "ci-info": "^2.0.0"
+      }
     },
     "is-date-object": {
       "version": "1.0.1",
@@ -3440,6 +3534,12 @@
         "iterate-iterator": "^1.0.1"
       }
     },
+    "its-name": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/its-name/-/its-name-1.0.0.tgz",
+      "integrity": "sha1-IGXxiD7LVoxl9xEt2/EjQB+uSvA=",
+      "dev": true
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3663,6 +3763,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/koalas/-/koalas-1.0.2.tgz",
       "integrity": "sha1-MYQz8HQjXbePrlZhoCqMpT7ilc0=",
+      "dev": true
+    },
+    "lazy-ass": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
+      "integrity": "sha1-eZllXoZGwX8In90YfRUNMyTVRRM=",
       "dev": true
     },
     "limiter": {
@@ -5229,6 +5335,12 @@
         "semver-compare": "^1.0.0"
       }
     },
+    "pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "dev": true
+    },
     "postgres-array": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
@@ -5395,6 +5507,12 @@
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
       "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
     },
+    "quote": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/quote/-/quote-0.4.0.tgz",
+      "integrity": "sha1-EIOSF/bBNiuJGUBE0psjP9fzLwE=",
+      "dev": true
+    },
     "rabbit-queue": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/rabbit-queue/-/rabbit-queue-5.0.0.tgz",
@@ -5416,6 +5534,12 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/race-until/-/race-until-2.3.1.tgz",
       "integrity": "sha512-NUpJpbEaZ3FL5UprkqzvvsY5HNEfJ8s1ba+MtQGdGBskm5u1K4tX546oi7BOjkw3LTtykOPQ///a7nKGEUd3uQ=="
+    },
+    "ramda": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
+      "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==",
+      "dev": true
     },
     "randombytes": {
       "version": "2.1.0",
@@ -5967,6 +6091,133 @@
       "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
       "integrity": "sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E="
     },
+    "snap-shot-compare": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/snap-shot-compare/-/snap-shot-compare-3.0.0.tgz",
+      "integrity": "sha512-bdwNOAGuKwPU+qsn0ASxTv+QfkXU+3VmkcDOkt965tes+JQQc8d6SfoLiEiRVhCey4v+ip2IjNUSbZm5nnkI9g==",
+      "dev": true,
+      "requires": {
+        "check-more-types": "2.24.0",
+        "debug": "4.1.1",
+        "disparity": "3.0.0",
+        "folktale": "2.3.2",
+        "lazy-ass": "1.6.0",
+        "strip-ansi": "5.2.0",
+        "variable-diff": "1.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
+    "snap-shot-core": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/snap-shot-core/-/snap-shot-core-10.2.4.tgz",
+      "integrity": "sha512-A7tkcfmvnRKge4VzFLAWA4UYMkvFY4TZKyL+D6hnHjI3HJ4pTepjG5DfR2ACeDKMzCSTQ5EwR2iOotI+Z37zsg==",
+      "dev": true,
+      "requires": {
+        "arg": "4.1.3",
+        "check-more-types": "2.24.0",
+        "common-tags": "1.8.0",
+        "debug": "4.3.1",
+        "escape-quotes": "1.0.2",
+        "folktale": "2.3.2",
+        "is-ci": "2.0.0",
+        "jsesc": "2.5.2",
+        "lazy-ass": "1.6.0",
+        "mkdirp": "1.0.4",
+        "pluralize": "8.0.0",
+        "quote": "0.4.0",
+        "ramda": "0.27.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
+    "snap-shot-it": {
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/snap-shot-it/-/snap-shot-it-7.9.6.tgz",
+      "integrity": "sha512-t/ADZfQ8EUk4J76S5cmynye7qg1ecUFqQfANiOMNy0sFmYUaqfx9K/AWwpdcpr3vFsDptM+zSuTtKD0A1EOLqA==",
+      "dev": true,
+      "requires": {
+        "@bahmutov/data-driven": "1.0.0",
+        "check-more-types": "2.24.0",
+        "common-tags": "1.8.0",
+        "debug": "4.3.1",
+        "has-only": "1.1.1",
+        "its-name": "1.0.0",
+        "lazy-ass": "1.6.0",
+        "pluralize": "8.0.0",
+        "ramda": "0.27.1",
+        "snap-shot-compare": "3.0.0",
+        "snap-shot-core": "10.2.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -6342,7 +6593,7 @@
     },
     "stubs": {
       "version": "3.0.0",
-      "resolved": "https://workable.jfrog.io/workable/api/npm/npm/stubs/-/stubs-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
       "integrity": "sha1-6NK6H6nJBXAwPAMLaQD31fiavls="
     },
     "superagent": {
@@ -6496,7 +6747,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://workable.jfrog.io/workable/api/npm/npm/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "tmp": {
@@ -6789,6 +7040,43 @@
       "requires": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "variable-diff": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/variable-diff/-/variable-diff-1.1.0.tgz",
+      "integrity": "sha1-0r1cZtt2wTh52W5qMG7cmJ35eNo=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.1",
+        "object-assign": "^4.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
       }
     },
     "vary": {

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "prom-client": "*",
     "should": "^13.2.3",
     "sinon": "^7.5.0",
+    "snap-shot-it": "^7.9.6",
     "supertest": "^4.0.2",
     "ts-node": "^9.1.1",
     "tslint": "^5.20.1",

--- a/src/initializers/diamorphosis.ts
+++ b/src/initializers/diamorphosis.ts
@@ -203,7 +203,12 @@ function addPostgresConfig(config) {
   config.postgres = {
     url: '',
     poolSize: 50,
-    ...config.postgres
+    useSsl: true,
+    ...config.postgres,
+    sslConfig: {
+      rejectUnauthorized: false,
+      ...config.postgres?.sslConfig
+    }
   };
 }
 

--- a/src/initializers/diamorphosis.ts
+++ b/src/initializers/diamorphosis.ts
@@ -207,6 +207,9 @@ function addPostgresConfig(config) {
     ...config.postgres,
     sslConfig: {
       rejectUnauthorized: false,
+      ca: '',
+      cert: '',
+      key: '',
       ...config.postgres?.sslConfig
     }
   };

--- a/src/initializers/postgres.ts
+++ b/src/initializers/postgres.ts
@@ -1,6 +1,7 @@
 import requireInjected from '../require-injected';
 import { getLogger } from 'log4js';
 import type * as PgTypes from 'pg';
+import { isEmpty } from 'lodash';
 
 const logger = getLogger('orka.postgres');
 let pool: PgTypes.Pool;
@@ -9,6 +10,11 @@ export default function postgres(config) {
   if (config.postgres?.url && !pool) {
     const { Pool }: typeof PgTypes = requireInjected('pg');
     const pgConfig = config.postgres;
+    
+    if (isEmpty(pgConfig.sslConfig?.ca)) delete pgConfig.sslConfig?.ca;
+    if (isEmpty(pgConfig.sslConfig?.cert)) delete pgConfig.sslConfig?.cert;
+    if (isEmpty(pgConfig.sslConfig?.key)) delete pgConfig.sslConfig?.key;
+
     pool = new Pool({
       connectionString: pgConfig.url,
       max: pgConfig.poolSize,

--- a/src/initializers/postgres.ts
+++ b/src/initializers/postgres.ts
@@ -8,12 +8,14 @@ let pool: PgTypes.Pool;
 export default function postgres(config) {
   if (config.postgres?.url && !pool) {
     const { Pool }: typeof PgTypes = requireInjected('pg');
+    const pgConfig = config.postgres;
     pool = new Pool({
-      connectionString: config.postgres.url,
-      max: config.postgres.poolSize,
-      ssl: config.postgres.sslConfig
+      connectionString: pgConfig.url,
+      max: pgConfig.poolSize,
+      ssl: pgConfig.useSsl ? pgConfig.sslConfig : undefined
     });
-    pool.on('error', (err) => {
+    logger.info(`Connected to Postgres! (${pgConfig.url.split('@')[1] || pgConfig.url})`);
+    pool.on('error', err => {
       logger.error('Unable to connect to database', err);
       throw err;
     });

--- a/src/initializers/postgres.ts
+++ b/src/initializers/postgres.ts
@@ -10,7 +10,7 @@ export default function postgres(config) {
   if (config.postgres?.url && !pool) {
     const { Pool }: typeof PgTypes = requireInjected('pg');
     const pgConfig = config.postgres;
-    
+
     if (isEmpty(pgConfig.sslConfig?.ca)) delete pgConfig.sslConfig?.ca;
     if (isEmpty(pgConfig.sslConfig?.cert)) delete pgConfig.sslConfig?.cert;
     if (isEmpty(pgConfig.sslConfig?.key)) delete pgConfig.sslConfig?.key;

--- a/test/diamorphosis/diamorphosis.test.ts
+++ b/test/diamorphosis/diamorphosis.test.ts
@@ -1,7 +1,7 @@
 import diamorphosis from '../../src/initializers/diamorphosis';
 import { OrkaOptions } from '../../src/typings/orka';
 import * as path from 'path';
-import * as assert from 'assert';
+import * as snapshot from 'snap-shot-it';
 
 describe('Diamorphosis Test', () => {
   describe('should set environment variables', () => {
@@ -149,6 +149,7 @@ describe('Diamorphosis Test', () => {
         config.log.console.should.equal(true);
         config.log.json.should.equal(false);
         config.riviere.styles.length.should.equal(0);
+        snapshot(config);
       })
     );
 
@@ -166,6 +167,7 @@ describe('Diamorphosis Test', () => {
         config.log.json.should.equal(true);
         config.riviere.styles.length.should.equal(1);
         config.riviere.styles[0].should.equal('json');
+        snapshot(config);
       })
     );
 
@@ -184,6 +186,7 @@ describe('Diamorphosis Test', () => {
         config.log.json.should.equal(true);
         config.riviere.styles.length.should.equal(1);
         config.riviere.styles[0].should.equal('json');
+        snapshot(config);
       })
     );
 
@@ -202,6 +205,7 @@ describe('Diamorphosis Test', () => {
         config.log.json.should.equal(true);
         config.riviere.styles.length.should.equal(1);
         config.riviere.styles[0].should.equal('json');
+        snapshot(config);
       })
     );
 
@@ -222,6 +226,7 @@ describe('Diamorphosis Test', () => {
         config.log.json.should.equal(true);
         config.riviere.styles.length.should.equal(1);
         config.riviere.styles[0].should.equal('simple');
+        snapshot(config);
       })
     );
 
@@ -242,6 +247,7 @@ describe('Diamorphosis Test', () => {
         config.log.console.should.equal(true);
         config.log.json.should.equal(false);
         config.riviere.styles.length.should.equal(0);
+        snapshot(config);
       });
     });
 
@@ -263,6 +269,7 @@ describe('Diamorphosis Test', () => {
         config.log.console.should.equal(true);
         config.log.json.should.equal(true);
         config.riviere.styles.should.eql(['json']);
+        snapshot(config);
       });
     });
   });

--- a/test/initializers/postgres.test.ts
+++ b/test/initializers/postgres.test.ts
@@ -56,13 +56,16 @@ describe('Test postgres connection', function () {
     ]);
   });
 
-  it('should use ssl to connect to postgres', () => {
+  it('should not use ssl to connect to postgres', () => {
     postgres({
       postgres: {
         url: 'postgres://localhost',
         useSsl: false,
         sslConfig: {
-          rejectUnauthorized: false
+          rejectUnauthorized: false,
+          ca: '',
+          cert: '',
+          key: ''
         }
       }
     });
@@ -72,6 +75,35 @@ describe('Test postgres connection', function () {
           connectionString: 'postgres://localhost',
           max: undefined,
           ssl: undefined
+        }
+      ]
+    ]);
+  });
+
+  it('should use ssl and ca,cert, key to connect to postgres', () => {
+    postgres({
+      postgres: {
+        url: 'postgres://localhost',
+        useSsl: true,
+        sslConfig: {
+          rejectUnauthorized: true,
+          ca: 'ca',
+          cert: 'cert',
+          key: 'key'
+        }
+      }
+    });
+    poolStub.args.should.eql([
+      [
+        {
+          connectionString: 'postgres://localhost',
+          max: undefined,
+          ssl: {
+            rejectUnauthorized: true,
+            ca: 'ca',
+            cert: 'cert',
+            key: 'key'
+          }
         }
       ]
     ]);

--- a/test/initializers/postgres.test.ts
+++ b/test/initializers/postgres.test.ts
@@ -4,7 +4,7 @@ import 'should';
 
 const sandbox = sinon.createSandbox();
 
-describe('Test postgres connection', function() {
+describe('Test postgres connection', function () {
   const config = {
     postgres: {
       url: 'postgres://localhost'
@@ -13,14 +13,14 @@ describe('Test postgres connection', function() {
   let postgres;
   let poolStub: sinon.SinonSpy;
 
-  beforeEach(async function() {
-    poolStub = sandbox.stub().returns({on: sandbox.stub()});
+  beforeEach(async function () {
+    poolStub = sandbox.stub().returns({ on: sandbox.stub() });
     delete require.cache[require.resolve('../../src/initializers/postgres')];
     mock('pg', { Pool: poolStub });
     ({ default: postgres } = await import('../../src/initializers/postgres'));
   });
 
-  afterEach(function() {
+  afterEach(function () {
     sandbox.restore();
     mock.stopAll();
   });
@@ -33,5 +33,47 @@ describe('Test postgres connection', function() {
   it('should not connect to postgres with no config', () => {
     postgres({});
     poolStub.called.should.be.false();
+  });
+
+  it('should use ssl to connect to postgres', () => {
+    postgres({
+      postgres: {
+        url: 'postgres://localhost',
+        useSsl: true,
+        sslConfig: {
+          rejectUnauthorized: false
+        }
+      }
+    });
+    poolStub.args.should.eql([
+      [
+        {
+          connectionString: 'postgres://localhost',
+          max: undefined,
+          ssl: { rejectUnauthorized: false }
+        }
+      ]
+    ]);
+  });
+
+  it('should use ssl to connect to postgres', () => {
+    postgres({
+      postgres: {
+        url: 'postgres://localhost',
+        useSsl: false,
+        sslConfig: {
+          rejectUnauthorized: false
+        }
+      }
+    });
+    poolStub.args.should.eql([
+      [
+        {
+          connectionString: 'postgres://localhost',
+          max: undefined,
+          ssl: undefined
+        }
+      ]
+    ]);
   });
 });


### PR DESCRIPTION
Currently we cannot add in config.postgres.sslConfig a default value that can be overwritten by each env. If provided postgres client will always try to use ssl.
So config.postgres.useSsl is added with this pr. This will default to true (that works well with all with all envs except local).