### PR TITLE
optionally check for already loaded dependencies prior to initialization

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -53,9 +53,9 @@ export default (defaults: Partial<OrkaOptions> = _defaults) => {
 
   options.appName ||= config?.app?.name;
   if (require.cache[require.resolve('koa')]) logger.warn('Koa was initialized before orka');
-  if (require.cache[require.resolve('mongoose')]) logger.warn('Mongoose was initialized before orka');
-  if (require.cache[require.resolve('amqplib')]) logger.warn('Amqplib was initialized before orka');
-  if (require.cache[require.resolve('pg')]) logger.warn('postgres was initialized before orka');
+  if (config.mongodb?.url && require.cache[require.resolve('mongoose')]) logger.warn('Mongoose was initialized before orka');
+  if (config.queue?.url && require.cache[require.resolve('amqplib')]) logger.warn('Amqplib was initialized before orka');
+  if (config.postgres?.url && require.cache[require.resolve('pg')]) logger.warn('postgres was initialized before orka');
 
   // Always call newrelic
   newrelic(config, options.appName);


### PR DESCRIPTION
Currently applications that do not depend on postgres fail with
```
Error: Cannot find module 'pg'
Require stack:
- <application-path>/node_modules/@workablehr/orka/build/builder.js
- <application-path>/node_modules/@workablehr/orka/build/orka.js
```
The check on 
https://github.com/Workable/orka/blob/47936e099ee8c08386f4f1e1e4f598f5db80a6f0/src/builder.ts#L58
fails since `require.resolve` throw an error when the dependency is not in the classpath.

This PR makes the checks for `pg`, `mongoose`, and `amqplib` optional; the checks take place only if each one of them is enabled and configured in the application.