### PR TITLE
[ENG-95] Log kafka expected errors as warnings

### DIFF
--- a/__snapshots__/diamorphosis.test.ts.js
+++ b/__snapshots__/diamorphosis.test.ts.js
@@ -94,7 +94,11 @@ exports['Diamorphosis Test should set json/console loggingvariables when nothing
     "clientId": "",
     "ssl": true,
     "log": {
-      "level": "info"
+      "level": "info",
+      "errorToWarn": [
+        "The group is rebalancing, re-joining",
+        "Response Heartbeat(key: 12, version: 3)"
+      ]
     },
     "certificates": {
       "key": "",
@@ -269,7 +273,11 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
     "clientId": "",
     "ssl": true,
     "log": {
-      "level": "info"
+      "level": "info",
+      "errorToWarn": [
+        "The group is rebalancing, re-joining",
+        "Response Heartbeat(key: 12, version: 3)"
+      ]
     },
     "certificates": {
       "key": "",
@@ -444,7 +452,11 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
     "clientId": "",
     "ssl": true,
     "log": {
-      "level": "info"
+      "level": "info",
+      "errorToWarn": [
+        "The group is rebalancing, re-joining",
+        "Response Heartbeat(key: 12, version: 3)"
+      ]
     },
     "certificates": {
       "key": "",
@@ -619,7 +631,11 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
     "clientId": "",
     "ssl": true,
     "log": {
-      "level": "info"
+      "level": "info",
+      "errorToWarn": [
+        "The group is rebalancing, re-joining",
+        "Response Heartbeat(key: 12, version: 3)"
+      ]
     },
     "certificates": {
       "key": "",
@@ -794,7 +810,11 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
     "clientId": "",
     "ssl": true,
     "log": {
-      "level": "info"
+      "level": "info",
+      "errorToWarn": [
+        "The group is rebalancing, re-joining",
+        "Response Heartbeat(key: 12, version: 3)"
+      ]
     },
     "certificates": {
       "key": "",
@@ -907,7 +927,11 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
       }
     },
     "log": {
-      "level": "info"
+      "level": "info",
+      "errorToWarn": [
+        "The group is rebalancing, re-joining",
+        "Response Heartbeat(key: 12, version: 3)"
+      ]
     },
     "sasl": {
       "mechanism": "",
@@ -1087,7 +1111,11 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
       }
     },
     "log": {
-      "level": "info"
+      "level": "info",
+      "errorToWarn": [
+        "The group is rebalancing, re-joining",
+        "Response Heartbeat(key: 12, version: 3)"
+      ]
     },
     "sasl": {
       "mechanism": "",

--- a/docs/integrations/kafka.md
+++ b/docs/integrations/kafka.md
@@ -40,7 +40,11 @@ module.exports = {
     "clientId": "", // An name identifying the application
     "ssl": true,
     "log": {
-      "level": "info"
+      "level": "info",
+      "errorToWarn": [
+        "The group is rebalancing, re-joining",
+        "Response Heartbeat(key: 12, version: 3)"
+      ]
     },
     "certificates": { // Should be given if the authentication is through certificates
       "key": "",

--- a/src/initializers/diamorphosis.ts
+++ b/src/initializers/diamorphosis.ts
@@ -136,6 +136,10 @@ function addKafkaConfig(config) {
     ...config.kafka,
     log: {
       level: 'info',
+      errorToWarn: [
+        'The group is rebalancing, re-joining',
+        'Response Heartbeat(key: 12, version: 3)'
+      ],
       ...config.kafka?.log
     },
     certificates: {

--- a/src/typings/kafka.d.ts
+++ b/src/typings/kafka.d.ts
@@ -31,5 +31,6 @@ export interface KafkaConfig {
   };
   log?: {
     level: 'info' | 'debug' | 'error' | 'warn' | 'nothing';
+    errorToWarn: string[];
   };
 }

--- a/test/diamorphosis/diamorphosis.test.ts
+++ b/test/diamorphosis/diamorphosis.test.ts
@@ -80,7 +80,13 @@ describe('Diamorphosis Test', () => {
           groupId: '',
           clientId: '',
           ssl: true,
-          log: { level: 'info' },
+          log: {
+            level: 'info',
+            errorToWarn: [
+              'The group is rebalancing, re-joining',
+              'Response Heartbeat(key: 12, version: 3)'
+            ]
+          },
           certificates: { key: '', cert: '', ca: [], rejectUnauthorized: false },
           sasl: { mechanism: '', username: '', password: '' },
           producer: {


### PR DESCRIPTION
## Summary
This will log errors like [this](https://app.honeybadger.io/projects/60297/faults/78990832) as warning.

This way we will get alerted only for non expected errors in the consumer.