### PR TITLE
Introduce a worker factory

### DIFF
--- a/__snapshots__/diamorphosis.test.ts.js
+++ b/__snapshots__/diamorphosis.test.ts.js
@@ -165,6 +165,10 @@ exports['Diamorphosis Test should set json/console loggingvariables when nothing
       "key": ""
     }
   },
+  "workers": {
+    "retryDelay": 3600000,
+    "initializationCheckDelay": 1000
+  },
   "requestContext": {
     "enabled": true,
     "logKeys": [
@@ -343,6 +347,10 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
       "cert": "",
       "key": ""
     }
+  },
+  "workers": {
+    "retryDelay": 3600000,
+    "initializationCheckDelay": 1000
   },
   "requestContext": {
     "enabled": true,
@@ -523,6 +531,10 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
       "key": ""
     }
   },
+  "workers": {
+    "retryDelay": 3600000,
+    "initializationCheckDelay": 1000
+  },
   "requestContext": {
     "enabled": true,
     "logKeys": [
@@ -702,6 +714,10 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
       "key": ""
     }
   },
+  "workers": {
+    "retryDelay": 3600000,
+    "initializationCheckDelay": 1000
+  },
   "requestContext": {
     "enabled": true,
     "logKeys": [
@@ -880,6 +896,10 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
       "cert": "",
       "key": ""
     }
+  },
+  "workers": {
+    "retryDelay": 3600000,
+    "initializationCheckDelay": 1000
   },
   "requestContext": {
     "enabled": true,
@@ -1064,6 +1084,10 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
       "cert": "",
       "key": ""
     }
+  },
+  "workers": {
+    "retryDelay": 3600000,
+    "initializationCheckDelay": 1000
   },
   "requestContext": {
     "enabled": true,
@@ -1250,6 +1274,10 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
       "cert": "",
       "key": ""
     }
+  },
+  "workers": {
+    "retryDelay": 3600000,
+    "initializationCheckDelay": 1000
   },
   "requestContext": {
     "enabled": true,

--- a/__snapshots__/index.test.ts.js
+++ b/__snapshots__/index.test.ts.js
@@ -1,0 +1,66 @@
+exports['Test worker initialize sets progress runs initializeCB updates state then executeCB and updates state 1'] = [
+  [
+    "Starting worker "
+  ],
+  [
+    "Worker initialized."
+  ],
+  [
+    "Worker starting processing"
+  ],
+  [
+    "Worker finished processing."
+  ]
+]
+
+exports['Test worker document already exists in db runs initializeCB updates state then executeCB and updates state 1'] = [
+  [
+    "Starting worker "
+  ],
+  [
+    "Worker initialized."
+  ],
+  [
+    "Worker starting processing"
+  ],
+  [
+    "Worker finished processing."
+  ]
+]
+
+exports['Test worker worker is already initialized runs executeCB and updates state 1'] = [
+  [
+    "Starting worker "
+  ],
+  [
+    "Worker starting processing"
+  ],
+  [
+    "Worker finished processing."
+  ]
+]
+
+exports['Test worker worker is already finished runs nothing 1'] = [
+  [
+    "Starting worker "
+  ],
+  [
+    "Worker finished processing. Will check again in 0.00016666666666666666 minutes"
+  ]
+]
+
+exports['Test worker worker throws error runs executeCB and updates state 1'] = [
+  [
+    "Starting worker "
+  ],
+  [
+    "Worker starting processing"
+  ]
+]
+
+exports['Test worker worker throws error runs executeCB and updates state 2'] = [
+  [
+    {},
+    "Errored will retry in  0.01 secs"
+  ]
+]

--- a/__snapshots__/index.test.ts.js
+++ b/__snapshots__/index.test.ts.js
@@ -40,16 +40,7 @@ exports['Test worker worker is already initialized runs executeCB and updates st
   ]
 ]
 
-exports['Test worker worker is already finished runs nothing 1'] = [
-  [
-    "Starting worker "
-  ],
-  [
-    "Worker finished processing. Will check again in 0.00016666666666666666 minutes"
-  ]
-]
-
-exports['Test worker worker throws error runs executeCB and updates state 1'] = [
+exports['Test worker worker throws error runs executeCB and updates state and reruns start after delay 1'] = [
   [
     "Starting worker "
   ],
@@ -58,9 +49,18 @@ exports['Test worker worker throws error runs executeCB and updates state 1'] = 
   ]
 ]
 
-exports['Test worker worker throws error runs executeCB and updates state 2'] = [
+exports['Test worker worker throws error runs executeCB and updates state and reruns start after delay 2'] = [
   [
     {},
     "Errored will retry in  0.01 secs"
+  ]
+]
+
+exports['Test worker worker is already finished will retry start after delay 1'] = [
+  [
+    "Starting worker "
+  ],
+  [
+    "Worker finished processing. Will check again in 0.00016666666666666666 minutes"
   ]
 ]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -216,15 +216,17 @@ You can find the default values below:
     }
   },
   "queue": {
-     "url": "",
-     "prefetch": 1,
-     "options": { // options that go into rabbit-queue constructor
-       "scheduledPublish": true
-      }
+    "url": "",
+    "prefetch": 1,
+    "options": {
+      // options that go into rabbit-queue constructor
+      "scheduledPublish": true
+    }
   },
   "mongodb": {
     "url": "",
-    "options": { // options that go into mongoose connect
+    "options": {
+      // options that go into mongoose connect
       "useNewUrlParser": true,
       "useCreateIndex": true,
       "useFindAndModify": false,
@@ -232,13 +234,13 @@ You can find the default values below:
     }
   },
   "postgres": {
-    "url":"",
+    "url": "",
     "useSsl": true,
     "sslConfig": {
       "rejectUnauthorized": false,
-        "ca": "",
-        "cert": "",
-        "key": ""
+      "ca": "",
+      "cert": "",
+      "key": ""
     }
   },
   "redis": {
@@ -249,11 +251,15 @@ You can find the default values below:
         "cert": "",
         "key": ""
       }
-  }
-}
+    }
+  },
   "requestContext": {
     "enabled": true,
     "logKeys": ["requestId", "visitor"]
+  },
+  "workers": {
+    "retryDelay": 3600000,
+    "initializationCheckDelay": 1000
   }
 }
 ```

--- a/docs/console.md
+++ b/docs/console.md
@@ -60,5 +60,5 @@ npx node-nc
 
 ```sh
 npx node-nc
-> getRabbit.publish('queue', {data:{}}, {correlationId:'test'})
+> getRabbit().publish('queue', {data:{}}, {correlationId:'test'})
 ```

--- a/docs/extra/index.md
+++ b/docs/extra/index.md
@@ -1,0 +1,6 @@
+---
+layout: default
+title: Extra
+nav_order: 7
+has_children: true
+---

--- a/docs/extra/workers.md
+++ b/docs/extra/workers.md
@@ -15,7 +15,7 @@ nav_order: 1
   {:toc}
 
 Orka is exposing a useful factory to create workers. This is a convenient boilerplate code to execute long running tasks keeping some state in a mongodb collection.
-Sometimes you need to execute long running tasks that need to continue from where the left when being restarted. E.g. Processing some million of rows in a table.
+Sometimes you need to execute long running tasks that need to continue from where it had left off when being restarted. E.g. Processing some million of rows in a table and keeping the last processed row.
 Orka's worker will automatically create and use a mongo collection called workerjob for this.
 
 ## Installation
@@ -63,7 +63,7 @@ async function execute(job, logger) {
 
 ```js
 const schema = {
-  payload: any;
+  payload: any; // to keep the progress
   name: string;
   initialized: boolean;
   finished: boolean;

--- a/docs/extra/workers.md
+++ b/docs/extra/workers.md
@@ -1,0 +1,79 @@
+---
+layout: default
+title: Workers
+parent: Extra
+nav_order: 1
+---
+
+# Workers
+{: .no_toc }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+  {:toc}
+
+Orka is exposing a useful factory to create workers. This is a convenient boilerplate code to execute long running tasks keeping some state in a mongodb collection.
+Sometimes you need to execute long running tasks that need to continue from where the left when being restarted. E.g. Processing some million of rows in a table.
+Orka's worker will automatically create and use a mongo collection called workerjob for this.
+
+## Installation
+
+To use the build in worker you need to have mongodb configured. See [mongodb](https://workable.github.io/orka/integrations/mongodb)
+
+### Configuration
+
+```js
+// config/config.js
+module.exports = {
+  workers: {
+    retryDelay: 1000 * 60 * 60, // 1 hour
+    initializationCheckDelay: 1000 // 1 min
+  }
+};
+```
+
+### Usage
+
+```js
+const o = orka({});
+
+const worker = o.createWorker('example-worker');
+
+worker.start(initialize, execute);
+
+// once this is completed model will be set to initialized=true so that it won't run again
+async function initialize(job, logger) {
+  job.payload = { progress: 0 };
+}
+
+// once this is completed model will be set to finished=true so that it won't run again
+async function execute(job, logger) {
+  const progress = job.payload.progress;
+  for (let i = progress + 1; i < 100; i++) {
+    await worker.WorkerJob.findOneAndUpdate({ _id: job._id }, { $set: { payload: { progress: i } } });
+    logger.info('setting progress to ', i);
+    await new Promise(r => setTimeout(r, 100));
+  }
+}
+```
+
+### WorkerJob schema
+
+```js
+const schema = {
+  payload: any;
+  name: string;
+  initialized: boolean;
+  finished: boolean;
+}
+```
+
+### Errors
+
+When errors occur worker will be restarted in config.workers.initializationCheckDelay ms
+
+### After execution is finished
+
+If worker is finished and the process runs again the worker will poll every config.workers.retryDelay the collection to see if something has changed.

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,9 @@ A modern Node.js framework based on koa@2 that comes powered with RabbitMQ, Kafk
 
 [Integrations](https://workable.github.io/orka/integrations/index)
 
-[Console](https://workable.github.io/orka/integrations/console)
+[Console](https://workable.github.io/orka/console)
+
+[Extra](https://workable.github.io/orka/extra/index)
 
 
 ## Changelog

--- a/examples/mongodb-example/worker.js
+++ b/examples/mongodb-example/worker.js
@@ -1,0 +1,16 @@
+const app = require('./app');
+const worker = app.createWorker('test-worker');
+
+worker.start(
+  (job, logger) => {
+    job.payload = { progress: 0 };
+  },
+  async (job, logger) => {
+    const progress = job.payload.progress;
+    for (let i = progress + 1; i < 100; i++) {
+      await worker.WorkerJob.findOneAndUpdate({ _id: job._id }, { $set: { payload: { progress: i } } });
+      logger.info('setting progress to ', i);
+      await new Promise(r => setTimeout(r, 100));
+    }
+  }
+);

--- a/src/initializers/diamorphosis.ts
+++ b/src/initializers/diamorphosis.ts
@@ -96,6 +96,7 @@ export default (config, orkaOptions: Partial<OrkaOptions>) => {
   addMongoDBConfig(config);
   addRedisConfig(config);
   addPostgresConfig(config);
+  addWorkersConfig(config);
 
   config.requestContext = {
     enabled: alsSupported(),
@@ -136,10 +137,7 @@ function addKafkaConfig(config) {
     ...config.kafka,
     log: {
       level: 'info',
-      errorToWarn: [
-        'The group is rebalancing, re-joining',
-        'Response Heartbeat(key: 12, version: 3)'
-      ],
+      errorToWarn: ['The group is rebalancing, re-joining', 'Response Heartbeat(key: 12, version: 3)'],
       ...config.kafka?.log
     },
     certificates: {
@@ -232,5 +230,13 @@ function addRedisConfig(config) {
         ...config?.redis?.options?.tls
       }
     }
+  };
+}
+
+function addWorkersConfig(config) {
+  config.workers = {
+    retryDelay: 1000 * 60 * 60,
+    initializationCheckDelay: 1000,
+    ...config.workers
   };
 }

--- a/src/initializers/worker/index.ts
+++ b/src/initializers/worker/index.ts
@@ -1,0 +1,61 @@
+import { Logger } from 'log4js';
+import type OrkaBuilderType from '../../orka-builder';
+import { getLogger } from '../log4js';
+import type { default as WorkerJobType, JobDocument } from './worker-job';
+
+export default class Worker {
+  logger: Logger;
+  WorkerJob: typeof WorkerJobType;
+  config: any;
+  constructor(public orkaInstance: OrkaBuilderType, public name: string) {
+    this.config = orkaInstance.config;
+  }
+
+  async start(
+    initializeCB: (job: JobDocument, logger: Logger) => Promise<JobDocument | void>,
+    executeCB: (job: JobDocument, logger: Logger) => void
+  ) {
+    await this.orkaInstance.initTasks();
+    this.logger = getLogger(`workers.${this.name}`);
+    this.WorkerJob = (await import('./worker-job')).default;
+    try {
+      let job = await this.init(initializeCB);
+
+      if (job.finished) {
+        this.logger.info(
+          `Worker finished processing. Will check again in ${this.config.workers.retryDelay / 60 / 1000} minutes`
+        );
+        await new Promise(r => setTimeout(r, this.config.workers.retryDelay));
+        return this.start(initializeCB, executeCB);
+      }
+
+      await this.exec(job, executeCB);
+    } catch (e) {
+      this.logger.error(e, `Errored will retry in  ${this.config.workers.initializationCheckDelay / 1000} secs`);
+      await new Promise(r => setTimeout(r, this.config.workers.initializationCheckDelay));
+      return this.start(initializeCB, executeCB);
+    }
+  }
+
+  async init(initializeCB: (job: JobDocument, logger: Logger) => Promise<JobDocument | void>) {
+    this.logger.info(`Starting worker `);
+    let job: JobDocument = await this.WorkerJob.findOne({ name: this.name });
+    if (!job) job = new this.WorkerJob({ name: this.name });
+    if (!job.initialized) {
+      const initializedJob = await initializeCB(job, this.logger);
+      if (initializedJob) job = initializedJob; // in case initializeCB has reloaded job
+      job.initialized = true;
+      await job.save();
+      this.logger.info('Worker initialized.');
+    }
+    return job;
+  }
+
+  async exec(job, executeCB: (job: JobDocument, logger: Logger) => void) {
+    this.logger.info('Worker starting processing');
+    await executeCB(job, this.logger);
+    job.finished = true;
+    await job.save();
+    this.logger.info('Worker finished processing.');
+  }
+}

--- a/src/initializers/worker/worker-job.ts
+++ b/src/initializers/worker/worker-job.ts
@@ -1,0 +1,23 @@
+import * as mongoose from 'mongoose';
+const Schema = mongoose.Schema;
+
+const Job = new Schema(
+  {
+    name: { type: String, unique: true },
+    payload: { type: Schema.Types.Mixed, default: {} },
+    initialized: Boolean,
+    finished: Boolean
+  },
+  { timestamps: {} }
+);
+
+export interface JobDocument extends mongoose.Document {
+  payload: any;
+  name: string;
+  initialized: boolean;
+  finished: boolean;
+}
+
+export type JobModel = mongoose.Model<JobDocument>;
+
+export default mongoose.model<JobDocument, JobModel>('WorkerJob', Job);

--- a/src/orka-builder.ts
+++ b/src/orka-builder.ts
@@ -27,6 +27,7 @@ import postgres from './initializers/postgres';
 import * as Koa from 'koa';
 import { AsyncLocalStorage } from 'async_hooks';
 import { alsSupported } from './utils';
+import type WorkerType from './initializers/worker';
 
 export default class OrkaBuilder {
   public static INSTANCE: OrkaBuilder;
@@ -163,7 +164,12 @@ export default class OrkaBuilder {
     return this;
   }
 
-  with(tasks) {
+  createWorker(name: string) {
+    const Worker: typeof WorkerType = require('./initializers/worker').default;
+    return new Worker(this, name);
+  }
+
+  with(tasks: ((config: any) => void)[] | ((config: any) => void)) {
     tasks = lodash.flatten([tasks]).filter(lodash.identity);
     tasks.forEach(task => this.queue.push(() => task(this.config)));
     return this;

--- a/test/env.ts
+++ b/test/env.ts
@@ -3,3 +3,5 @@ process.env.LOG_LEVEL = 'fatal';
 process.env.PRINTLOGO = 'false';
 process.env.NODE_ENV = 'test';
 process.env.RIVIERE_ENABLED = 'false';
+// Makes running tests a lot faster and less resource consuming
+process.env.TS_NODE_TRANSPILE_ONLY = 'true';

--- a/test/orka-builder.test.ts
+++ b/test/orka-builder.test.ts
@@ -1,20 +1,35 @@
 import OrkaBuilder from '../src/orka-builder';
 import * as sinon from 'sinon';
 import * as redis from '../src/initializers/redis';
+import type WorkerType from '../src/initializers/worker';
 
 const sandbox = sinon.createSandbox();
 
-describe('orka-builder', function() {
-  afterEach(function() {
+describe('orka-builder', function () {
+  afterEach(function () {
     sandbox.restore();
   });
 
-  it('calls redis', async function() {
-    const config = {};
-    const stub = sandbox.stub(redis, 'createRedisConnection');
-    const builder = new OrkaBuilder({}, { redis: config }, () => undefined, sandbox.stub());
-    builder.withRedis();
-    await builder.initTasks();
-    stub.args.should.eql([[config]]);
+  describe('withRedis', function () {
+    it('calls redis', async function () {
+      const config = {};
+      const stub = sandbox.stub(redis, 'createRedisConnection');
+      const builder = new OrkaBuilder({}, { redis: config }, () => undefined, sandbox.stub());
+      builder.withRedis();
+      await builder.initTasks();
+      stub.args.should.eql([[config]]);
+    });
+  });
+
+  describe('createWorker', function () {
+    it('creates and returns worker', async function () {
+      const Worker: { default: typeof WorkerType } = require('../src/initializers/worker');
+      const obj = {};
+      const stub = sandbox.stub(Worker, 'default').returns(obj);
+      const builder = new OrkaBuilder({}, {}, () => undefined, sandbox.stub());
+      const worker = builder.createWorker('name');
+      worker.should.equal(obj);
+      stub.args.should.eql([[builder, 'name']]);
+    });
   });
 });

--- a/test/worker/index.test.ts
+++ b/test/worker/index.test.ts
@@ -1,0 +1,195 @@
+import Worker from '../../src/initializers/worker';
+import WorkerJob from '../../src/initializers/worker/worker-job';
+import OrkaBuilder from '../../src/orka-builder';
+import * as sinon from 'sinon';
+import * as snapshot from 'snap-shot-it';
+import * as mongoose from 'mongoose';
+import * as should from 'should';
+import { getLogger } from '../../src/initializers/log4js';
+import { start } from '@google-cloud/debug-agent';
+const sandbox = sinon.createSandbox();
+
+describe('Test worker', function () {
+  before(function () {
+    mongoose.connect('mongodb://localhost/orka');
+  });
+
+  beforeEach(async function () {
+    await WorkerJob.deleteMany({});
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  after(async function () {
+    mongoose.connection.close();
+  });
+
+  context('initialize sets progress', function () {
+    it('runs initializeCB updates state then executeCB and updates state', async function () {
+      const logger = getLogger(`workers.name`);
+      sandbox.stub(logger, 'info');
+      const orka = new OrkaBuilder({}, {}, () => undefined, sandbox.stub());
+      const worker = new Worker(orka, 'name');
+      let resolveInitialize;
+      let resolveExecuteCB;
+      let init;
+      let exec;
+      const initialized = new Promise(r => (init = r));
+      const executed = new Promise(r => (exec = r));
+      const initializeCB = async job => {
+        init();
+        job.payload = { progress: 0 };
+
+        await new Promise(r => (resolveInitialize = r));
+      };
+      const executeCB = async job => {
+        exec();
+        job.payload = { progress: 100 };
+        await new Promise(r => (resolveExecuteCB = r));
+      };
+      const start = worker.start(initializeCB, executeCB);
+      should.equal(null, await WorkerJob.findOne({ name: 'name' }));
+      await initialized;
+      await resolveInitialize();
+      await executed;
+      (await WorkerJob.findOne({ name: 'name' })).toJSON().should.containDeep({
+        payload: {
+          progress: 0
+        },
+        initialized: true,
+        finished: undefined
+      });
+      resolveExecuteCB();
+      await start;
+      (await WorkerJob.findOne({ name: 'name' })).toJSON().should.containDeep({
+        payload: {
+          progress: 100
+        },
+        initialized: true,
+        finished: true
+      });
+      snapshot((logger.info as any).args);
+    });
+  });
+
+  context('document already exists in db', function () {
+    it('runs initializeCB updates state then executeCB and updates state', async function () {
+      await WorkerJob.create({ name: 'name', initialized: false });
+      const logger = getLogger(`workers.name`);
+      sandbox.stub(logger, 'info');
+      const orka = new OrkaBuilder({}, {}, () => undefined, sandbox.stub());
+      const worker = new Worker(orka, 'name');
+      let resolveInitialize;
+      let resolveExecuteCB;
+      let init;
+      let exec;
+      const initialized = new Promise(r => (init = r));
+      const executed = new Promise(r => (exec = r));
+      const initializeCB = async job => {
+        init();
+        job.payload = { progress: 0 };
+        await new Promise(r => (resolveInitialize = r));
+        return job;
+      };
+      const executeCB = async job => {
+        exec();
+        job.payload = { progress: 100 };
+        await new Promise(r => (resolveExecuteCB = r));
+      };
+      const start = worker.start(initializeCB, executeCB);
+      await initialized;
+      resolveInitialize();
+      await executed;
+      (await WorkerJob.findOne({ name: 'name' })).toJSON().should.containDeep({
+        payload: {
+          progress: 0
+        },
+        initialized: true,
+        finished: undefined
+      });
+      resolveExecuteCB();
+      await start;
+      (await WorkerJob.findOne({ name: 'name' })).toJSON().should.containDeep({
+        payload: {
+          progress: 100
+        },
+        initialized: true,
+        finished: true
+      });
+      snapshot((logger.info as any).args);
+    });
+  });
+
+  context('worker is already initialized', function () {
+    it('runs executeCB and updates state', async function () {
+      await WorkerJob.create({ name: 'name', initialized: true });
+      const logger = getLogger(`workers.name`);
+      sandbox.stub(logger, 'info');
+      const orka = new OrkaBuilder({}, {}, () => undefined, sandbox.stub());
+      const worker = new Worker(orka, 'name');
+      let resolveExecuteCB;
+      let exec;
+      const executed = new Promise(r => (exec = r));
+      const initializeCB = async job => ({});
+      const executeCB = async job => {
+        exec();
+        job.payload = { progress: 100 };
+        await new Promise(r => (resolveExecuteCB = r));
+      };
+      const start = worker.start(initializeCB as any, executeCB);
+      await executed;
+      resolveExecuteCB();
+      await start;
+      (await WorkerJob.findOne({ name: 'name' })).toJSON().should.containDeep({
+        payload: {
+          progress: 100
+        },
+        initialized: true,
+        finished: true
+      });
+      snapshot((logger.info as any).args);
+    });
+  });
+
+  context('worker throws error', function () {
+    it('runs executeCB and updates state', async function () {
+      await WorkerJob.create({ name: 'name', initialized: true });
+      const logger = getLogger(`workers.name`);
+      sandbox.stub(logger, 'info');
+      sandbox.stub(logger, 'error');
+      const orka = new OrkaBuilder({}, { workers: { initializationCheckDelay: 10 } }, () => undefined, sandbox.stub());
+      const worker = new Worker(orka, 'name');
+      const initializeCB = async job => ({});
+      const executeCB = async job => {
+        throw new Error('test');
+      };
+      const start = worker.start(initializeCB as any, executeCB);
+      worker.start = () => ({});
+      await start;
+      snapshot((logger.info as any).args);
+      snapshot((logger.error as any).args);
+    });
+  });
+
+  context('worker is already finished', function () {
+    it('runs nothing', async function () {
+      await WorkerJob.create({ name: 'name', initialized: true, finished: true });
+      const logger = getLogger(`workers.name`);
+      sandbox.stub(logger, 'info');
+      const orka = new OrkaBuilder({}, { workers: { retryDelay: 10 } }, () => undefined, sandbox.stub());
+      const worker = new Worker(orka, 'name');
+      const initializeCB = async job => {
+        job.payload = { progress: 0 };
+      };
+      const executeCB = async job => {
+        job.payload = { progress: 100 };
+      };
+      const start = worker.start(initializeCB, executeCB);
+      worker.start = () => ({});
+      await start;
+      snapshot((logger.info as any).args);
+    });
+  });
+});


### PR DESCRIPTION
We use a similar worker in one of our services.
It uses a mongo collection to save the state of the worker so that when it starts again it will continue from where it had left off.
This seems to be useful in other services too so I am adding it here.
It is mostly boilerplate code that initializes all orka tasks for the worker to have them available.
Also it does the most of the logging - mongodb status updates.