### PR TITLE
Reduce the percentiles logged to Prometheus

### DIFF
--- a/__snapshots__/diamorphosis.test.ts.js
+++ b/__snapshots__/diamorphosis.test.ts.js
@@ -33,6 +33,13 @@ exports['Diamorphosis Test should set json/console loggingvariables when nothing
       "name": "flow_duration_seconds",
       "help": "Flow duration in seconds",
       "ageBuckets": 10,
+      "percentiles": [
+        0.05,
+        0.5,
+        0.9,
+        0.95,
+        0.999
+      ],
       "maxAgeSeconds": 60
     },
     "eventSummary": {
@@ -45,7 +52,14 @@ exports['Diamorphosis Test should set json/console loggingvariables when nothing
       "name": "events",
       "help": "Custom events, eg: event occurences, event lengths",
       "ageBuckets": 10,
-      "maxAgeSeconds": 60
+      "maxAgeSeconds": 60,
+      "percentiles": [
+        0.05,
+        0.5,
+        0.9,
+        0.95,
+        0.999
+      ]
     }
   },
   "printLogo": true,
@@ -127,8 +141,8 @@ exports['Diamorphosis Test should set json/console loggingvariables when nothing
         "password": ""
       }
     },
-    connectionTimeout: 1000,
-    authenticationTimeout: 1000
+    "connectionTimeout": 1000,
+    "authenticationTimeout": 1000
   },
   "queue": {
     "url": "",
@@ -230,6 +244,13 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
       "name": "flow_duration_seconds",
       "help": "Flow duration in seconds",
       "ageBuckets": 10,
+      "percentiles": [
+        0.05,
+        0.5,
+        0.9,
+        0.95,
+        0.999
+      ],
       "maxAgeSeconds": 60
     },
     "eventSummary": {
@@ -242,7 +263,14 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
       "name": "events",
       "help": "Custom events, eg: event occurences, event lengths",
       "ageBuckets": 10,
-      "maxAgeSeconds": 60
+      "maxAgeSeconds": 60,
+      "percentiles": [
+        0.05,
+        0.5,
+        0.9,
+        0.95,
+        0.999
+      ]
     }
   },
   "printLogo": true,
@@ -320,8 +348,8 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
         "password": ""
       }
     },
-    connectionTimeout: 1000,
-    authenticationTimeout: 1000
+    "connectionTimeout": 1000,
+    "authenticationTimeout": 1000
   },
   "queue": {
     "url": "",
@@ -423,6 +451,13 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
       "name": "flow_duration_seconds",
       "help": "Flow duration in seconds",
       "ageBuckets": 10,
+      "percentiles": [
+        0.05,
+        0.5,
+        0.9,
+        0.95,
+        0.999
+      ],
       "maxAgeSeconds": 60
     },
     "eventSummary": {
@@ -435,7 +470,14 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
       "name": "events",
       "help": "Custom events, eg: event occurences, event lengths",
       "ageBuckets": 10,
-      "maxAgeSeconds": 60
+      "maxAgeSeconds": 60,
+      "percentiles": [
+        0.05,
+        0.5,
+        0.9,
+        0.95,
+        0.999
+      ]
     }
   },
   "printLogo": true,
@@ -513,8 +555,8 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
         "password": ""
       }
     },
-    connectionTimeout: 1000,
-    authenticationTimeout: 1000
+    "connectionTimeout": 1000,
+    "authenticationTimeout": 1000
   },
   "queue": {
     "url": "",
@@ -616,6 +658,13 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
       "name": "flow_duration_seconds",
       "help": "Flow duration in seconds",
       "ageBuckets": 10,
+      "percentiles": [
+        0.05,
+        0.5,
+        0.9,
+        0.95,
+        0.999
+      ],
       "maxAgeSeconds": 60
     },
     "eventSummary": {
@@ -628,7 +677,14 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
       "name": "events",
       "help": "Custom events, eg: event occurences, event lengths",
       "ageBuckets": 10,
-      "maxAgeSeconds": 60
+      "maxAgeSeconds": 60,
+      "percentiles": [
+        0.05,
+        0.5,
+        0.9,
+        0.95,
+        0.999
+      ]
     }
   },
   "printLogo": true,
@@ -706,8 +762,8 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
         "password": ""
       }
     },
-    connectionTimeout: 1000,
-    authenticationTimeout: 1000
+    "connectionTimeout": 1000,
+    "authenticationTimeout": 1000
   },
   "queue": {
     "url": "",
@@ -828,6 +884,13 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
       "name": "flow_duration_seconds",
       "help": "Flow duration in seconds",
       "ageBuckets": 10,
+      "percentiles": [
+        0.05,
+        0.5,
+        0.9,
+        0.95,
+        0.999
+      ],
       "maxAgeSeconds": 60
     },
     "eventSummary": {
@@ -840,7 +903,14 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
       "name": "events",
       "help": "Custom events, eg: event occurences, event lengths",
       "ageBuckets": 10,
-      "maxAgeSeconds": 60
+      "maxAgeSeconds": 60,
+      "percentiles": [
+        0.05,
+        0.5,
+        0.9,
+        0.95,
+        0.999
+      ]
     }
   },
   "printLogo": true,
@@ -899,8 +969,8 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
         "password": ""
       }
     },
-    connectionTimeout: 1000,
-    authenticationTimeout: 1000
+    "connectionTimeout": 1000,
+    "authenticationTimeout": 1000
   },
   "queue": {
     "url": "",
@@ -1008,8 +1078,8 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
       "username": "",
       "password": ""
     },
-    connectionTimeout: 1000,
-    authenticationTimeout: 1000
+    "connectionTimeout": 1000,
+    "authenticationTimeout": 1000
   },
   "healthCheck": {
     "kafka": true,
@@ -1052,6 +1122,13 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
       "name": "flow_duration_seconds",
       "help": "Flow duration in seconds",
       "ageBuckets": 10,
+      "percentiles": [
+        0.05,
+        0.5,
+        0.9,
+        0.95,
+        0.999
+      ],
       "maxAgeSeconds": 60
     },
     "eventSummary": {
@@ -1064,7 +1141,14 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
       "name": "events",
       "help": "Custom events, eg: event occurences, event lengths",
       "ageBuckets": 10,
-      "maxAgeSeconds": 60
+      "maxAgeSeconds": 60,
+      "percentiles": [
+        0.05,
+        0.5,
+        0.9,
+        0.95,
+        0.999
+      ]
     }
   },
   "printLogo": false,
@@ -1206,8 +1290,8 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
       "username": "",
       "password": ""
     },
-    connectionTimeout: 1000,
-    authenticationTimeout: 1000
+    "connectionTimeout": 1000,
+    "authenticationTimeout": 1000
   },
   "healthCheck": {
     "kafka": true,
@@ -1250,6 +1334,13 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
       "name": "flow_duration_seconds",
       "help": "Flow duration in seconds",
       "ageBuckets": 10,
+      "percentiles": [
+        0.05,
+        0.5,
+        0.9,
+        0.95,
+        0.999
+      ],
       "maxAgeSeconds": 60
     },
     "eventSummary": {
@@ -1262,7 +1353,14 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
       "name": "events",
       "help": "Custom events, eg: event occurences, event lengths",
       "ageBuckets": 10,
-      "maxAgeSeconds": 60
+      "maxAgeSeconds": 60,
+      "percentiles": [
+        0.05,
+        0.5,
+        0.9,
+        0.95,
+        0.999
+      ]
     }
   },
   "printLogo": false,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -143,6 +143,7 @@ You can find the default values below:
       "name": "flow_duration_seconds",
       "help": "Flow duration in seconds",
       "ageBuckets": 10,
+      "percentiles": [0.05, 0.5, 0.9, 0.95, 0.999],
       "maxAgeSeconds": 60
     },
     "eventSummary": {
@@ -151,6 +152,7 @@ You can find the default values below:
       "type": "external",
       "name": "events",
       "help": "Custom events, eg: event occurences, event lengths",
+      "percentiles": [0.05, 0.5, 0.9, 0.95, 0.999],
       "ageBuckets": 10,
       "maxAgeSeconds": 60
     }
@@ -255,7 +257,15 @@ You can find the default values below:
     "logKeys": ["requestId", "visitor"],
     "istioTraceContextHeaders": {
       "enabled": true,
-      "headers": ["x-request-id", "x-b3-traceid", "x-b3-spanid", "x-b3-parentspanid", "x-b3-sampled", "x-b3-flags", "x-ot-span-context"]
+      "headers": [
+        "x-request-id",
+        "x-b3-traceid",
+        "x-b3-spanid",
+        "x-b3-parentspanid",
+        "x-b3-sampled",
+        "x-b3-flags",
+        "x-ot-span-context"
+      ]
     }
   },
   "workers": {

--- a/src/initializers/diamorphosis.ts
+++ b/src/initializers/diamorphosis.ts
@@ -34,6 +34,8 @@ export default (config, orkaOptions: Partial<OrkaOptions>) => {
       name: 'flow_duration_seconds',
       help: 'Flow duration in seconds',
       ageBuckets: 10,
+      // default: 0.01, 0.05, 0.5, 0.9, 0.95, 0.99, 0.999
+      percentiles: [0.05, 0.5, 0.9, 0.95, 0.999],
       maxAgeSeconds: 60,
       ...config.prometheus?.timeSummary
     },
@@ -45,6 +47,8 @@ export default (config, orkaOptions: Partial<OrkaOptions>) => {
       help: 'Custom events, eg: event occurences, event lengths',
       ageBuckets: 10,
       maxAgeSeconds: 60,
+      // default: 0.01, 0.05, 0.5, 0.9, 0.95, 0.99, 0.999
+      percentiles: [0.05, 0.5, 0.9, 0.95, 0.999],
       ...config.prometheus?.eventSummary
     }
   };
@@ -111,7 +115,7 @@ export default (config, orkaOptions: Partial<OrkaOptions>) => {
         'x-b3-parentspanid',
         'x-b3-sampled',
         'x-b3-flags',
-        'x-ot-span-context',
+        'x-ot-span-context'
       ],
       ...config.requestContext?.istioTraceContextHeaders
     },

--- a/src/initializers/prometheus/prometheus.ts
+++ b/src/initializers/prometheus/prometheus.ts
@@ -36,6 +36,7 @@ type metricOptionsType = {
   type: metricType;
   name: string;
   help: string;
+  percentiles: number[];
   ageBuckets: number;
   maxAgeSeconds: number;
 };
@@ -64,6 +65,7 @@ export default class Prometheus {
     if (metric?.enabled) {
       this.timeSummary = this.registerSummary(metric.type, metric.name, metric.help, metric.labels, {
         ageBuckets: metric.ageBuckets,
+        percentiles: metric.percentiles,
         maxAgeSeconds: metric.maxAgeSeconds
       });
     }
@@ -71,6 +73,7 @@ export default class Prometheus {
     if (metric?.enabled) {
       this.eventSummary = this.registerSummary(metric.type, metric.name, metric.help, metric.labels, {
         ageBuckets: metric.ageBuckets,
+        percentiles: metric.percentiles,
         maxAgeSeconds: metric.maxAgeSeconds
       });
     }


### PR DESCRIPTION
Removes 30% (2/7) of percentiles logged by default.
This is of course overwriteable by env variables