### PR TITLE
Joi fixes & riviere default config override

### DIFF
--- a/src/initializers/diamorphosis.ts
+++ b/src/initializers/diamorphosis.ts
@@ -68,14 +68,18 @@ export default (config, orkaOptions: Partial<OrkaOptions>) => {
     enabled: true,
     inbound: {
       request: {
-        enabled: false
-      }
+        enabled: false,
+        ...config.riviere?.inbound?.request
+      },
+      ...config.riviere?.inbound
     },
     outbound: {
       blacklistedPathRegex: new RegExp('^/v0.4/traces$', 'i'),
       request: {
-        enabled: false
-      }
+        enabled: false,
+        ...config.riviere?.outbound?.request
+      },
+      ...config.riviere?.outbound
     },
     color: true,
     styles: [],

--- a/src/initializers/diamorphosis.ts
+++ b/src/initializers/diamorphosis.ts
@@ -67,19 +67,19 @@ export default (config, orkaOptions: Partial<OrkaOptions>) => {
   config.riviere = {
     enabled: true,
     inbound: {
+      ...config.riviere?.inbound,
       request: {
         enabled: false,
         ...config.riviere?.inbound?.request
-      },
-      ...config.riviere?.inbound
+      }
     },
     outbound: {
       blacklistedPathRegex: new RegExp('^/v0.4/traces$', 'i'),
+      ...config.riviere?.outbound,
       request: {
         enabled: false,
         ...config.riviere?.outbound?.request
-      },
-      ...config.riviere?.outbound
+      }
     },
     color: true,
     styles: [],

--- a/src/initializers/joi.ts
+++ b/src/initializers/joi.ts
@@ -16,7 +16,7 @@ interface JoiWithExtensions extends _Joi.Root {
   hexColor(): _Joi.StringSchema;
   objectId(): _Joi.StringSchema;
   phone(): _Joi.StringSchema & { stripIfInvalid: () => _Joi.StringSchema };
-  safeHtml(): _Joi.StringSchema & { allowEmpty: () => _Joi.StringSchema };
+  safeHtml(): _Joi.StringSchema;
   stringWithEmpty(): _Joi.StringSchema & { defaultIfEmpty: (v: string) => _Joi.StringSchema };
   string(): _Joi.StringSchema & { defaultIfEmpty: (v: string) => _Joi.StringSchema };
   urlInOwnS3(): _Joi.StringSchema & { bucket: (name: string) => _Joi.StringSchema };
@@ -171,14 +171,6 @@ const Joi: JoiWithExtensions = _Joi.extend(
   joi => ({
     type: 'safeHtml',
     base: joi.string(),
-    rules: {
-      allowEmpty: {
-        method() {
-          // @ts-ignore
-          return this.$_root.allow('').allow(null);
-        }
-      }
-    },
     prepare: value => ({
       value: sanitizeHtml(value, {
         allowedTags: ['b', 'i', 'u', 'span', 'p', 'div', 'a', 'font'],

--- a/test/initializers/joi.test.ts
+++ b/test/initializers/joi.test.ts
@@ -140,7 +140,7 @@ describe('joi extensions', function () {
         '<a href="/j/ABCDEFG">banana</a>'
       );
     });
-    it('invalid tags', function() {
+    it.only('invalid tags', function() {
       Joi.safeHtml().validate('<script src="javascript:alert(1);">asd</script><p>foo</p>').value.should.equal(
         '<p>foo</p>'
       );
@@ -152,7 +152,7 @@ describe('joi extensions', function () {
       );
     });
     it('required', function() {
-      should(Joi.safeHtml().allowEmpty().validate('').error).be.undefined();
+      should(Joi.safeHtml().allow('', null).validate('').error).be.undefined();
       Joi.safeHtml().validate('').error.message.should.equal('"value" is not allowed to be empty');
     });
   });

--- a/test/initializers/joi.test.ts
+++ b/test/initializers/joi.test.ts
@@ -140,7 +140,7 @@ describe('joi extensions', function () {
         '<a href="/j/ABCDEFG">banana</a>'
       );
     });
-    it.only('invalid tags', function() {
+    it('invalid tags', function() {
       Joi.safeHtml().validate('<script src="javascript:alert(1);">asd</script><p>foo</p>').value.should.equal(
         '<p>foo</p>'
       );


### PR DESCRIPTION
## Summary
* joi: Remove buggy allowEmpty rule
  * Someone can replace with `.allow('null', '')`
* riviere: override defaults inbound/outbound if needed