### PR TITLE
Teach orka to getRootSpan for all versions of dd-trace

### DIFF
--- a/src/helpers/get-root-span.ts
+++ b/src/helpers/get-root-span.ts
@@ -1,6 +1,8 @@
-import { getDatadogTracer } from '../initializers/datadog/index';
+import { getDatadogTracer, isDatadogEnabled } from '../initializers/datadog/index';
 
 export default function getRootSpan(ctx) {
+  if (!isDatadogEnabled()) return;
+
   let ddSpan = ctx.req?._datadog?.span;
   if (!ddSpan) {
     const activeSpan = getDatadogTracer()?.scope()?.active();

--- a/src/helpers/get-root-span.ts
+++ b/src/helpers/get-root-span.ts
@@ -1,0 +1,10 @@
+import { getDatadogTracer } from '../initializers/datadog/index';
+
+export default function getRootSpan(ctx) {
+  let ddSpan = ctx.req?._datadog?.span;
+  if (!ddSpan) {
+    const activeSpan = getDatadogTracer().scope().active();
+    if (activeSpan) ddSpan = activeSpan.context()._trace.started[0];
+  }
+  return ddSpan;
+}

--- a/src/helpers/get-root-span.ts
+++ b/src/helpers/get-root-span.ts
@@ -1,12 +1,19 @@
 import { getDatadogTracer, isDatadogEnabled } from '../initializers/datadog/index';
+import { getLogger } from '../initializers/log4js';
+
+const logger = getLogger('orka.helpers.get-root-span');
 
 export default function getRootSpan(ctx) {
   if (!isDatadogEnabled()) return;
 
   let ddSpan = ctx.req?._datadog?.span;
   if (!ddSpan) {
-    const activeSpan = getDatadogTracer()?.scope()?.active();
-    if (activeSpan?.context()?._trace?.started.length > 0) ddSpan = activeSpan?.context()?._trace?.started[0];
+    try {
+      const activeSpan = getDatadogTracer()?.scope()?.active();
+      if (activeSpan?.context()?._trace?.started.length > 0) ddSpan = activeSpan?.context()?._trace?.started[0];
+    } catch (e) {
+      logger.error('dd-trace error trying to find root span', e);
+    }
   }
   return ddSpan;
 }

--- a/src/helpers/get-root-span.ts
+++ b/src/helpers/get-root-span.ts
@@ -3,8 +3,8 @@ import { getDatadogTracer } from '../initializers/datadog/index';
 export default function getRootSpan(ctx) {
   let ddSpan = ctx.req?._datadog?.span;
   if (!ddSpan) {
-    const activeSpan = getDatadogTracer().scope().active();
-    if (activeSpan) ddSpan = activeSpan.context()._trace.started[0];
+    const activeSpan = getDatadogTracer()?.scope()?.active();
+    if (activeSpan?.context()?._trace?.started.length > 0) ddSpan = activeSpan?.context()?._trace?.started[0];
   }
   return ddSpan;
 }

--- a/src/helpers/get-root-span.ts
+++ b/src/helpers/get-root-span.ts
@@ -12,7 +12,7 @@ export default function getRootSpan(ctx) {
       const activeSpan = getDatadogTracer()?.scope()?.active();
       if (activeSpan?.context()?._trace?.started.length > 0) ddSpan = activeSpan?.context()?._trace?.started[0];
     } catch (e) {
-      logger.error('dd-trace error trying to find root span', e);
+      logger.error(e, 'dd-trace error trying to find root span');
     }
   }
   return ddSpan;

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,9 +1,6 @@
 import logMetrics from './log-metrics';
 import axiosErrorInterceptor from './interceptors/axios-error-interceptor';
 import getLock from './get-lock';
+import getRootSpan from './get-root-span';
 
-export {
-  logMetrics,
-  axiosErrorInterceptor,
-  getLock
-};
+export { logMetrics, axiosErrorInterceptor, getLock, getRootSpan };

--- a/src/initializers/datadog/index.ts
+++ b/src/initializers/datadog/index.ts
@@ -3,7 +3,7 @@ import { getLogger } from '../log4js';
 
 let tracer;
 export default config => {
-  if (process.env.DD_SERVICE && process.env.DD_ENV) {
+  if (isDatadogEnabled()) {
     tracer = requireInjected('dd-trace').init();
     tracer.use('koa', {
       blacklist: config?.datadog?.blacklistedPaths,
@@ -18,4 +18,8 @@ export const getDatadogTracer = () => {
     getLogger('orka.initializers.datadog').error(new Error('Datadog tracer required before initialized.'));
   }
   return tracer;
+};
+
+export const isDatadogEnabled = () => {
+  return process.env.DD_SERVICE && process.env.DD_ENV;
 };

--- a/src/initializers/datadog/index.ts
+++ b/src/initializers/datadog/index.ts
@@ -5,6 +5,7 @@ let tracer;
 export default config => {
   if (process.env.DD_SERVICE && process.env.DD_ENV) {
     tracer = requireInjected('dd-trace').init();
+    tracer.use('http', { client: false })
     tracer.use('koa', {
       blacklist: config?.datadog?.blacklistedPaths,
       blocklist: config?.datadog?.blacklistedPaths,

--- a/src/initializers/datadog/index.ts
+++ b/src/initializers/datadog/index.ts
@@ -11,9 +11,9 @@ export default config => {
       blocklist: config?.datadog?.blacklistedPaths,
       hooks: {
         request: (span, ctx) => {
-          getLogger('orka.initializers.datadog').info(`ctx.req: ${JSON.stringify(ctx.req)}`);
-          getLogger('orka.initializers.datadog').info(`ctx.request: ${JSON.stringify(ctx.request)}`);
-          if (!ctx.req?._datadog) ctx.req = { _datadog: span };
+          if (!ctx.req) ctx.req = {};
+          if (!ctx.req._datadog) ctx.req._datadog = {};
+          ctx.req._datadog = { span: span.context()._trace.started[0] };
         }
       },
       ...config.datadog

--- a/src/initializers/datadog/index.ts
+++ b/src/initializers/datadog/index.ts
@@ -5,17 +5,9 @@ let tracer;
 export default config => {
   if (process.env.DD_SERVICE && process.env.DD_ENV) {
     tracer = requireInjected('dd-trace').init();
-    tracer.use('http', { client: false });
     tracer.use('koa', {
       blacklist: config?.datadog?.blacklistedPaths,
       blocklist: config?.datadog?.blacklistedPaths,
-      hooks: {
-        request: (span, ctx) => {
-          if (!ctx.req) ctx.req = {};
-          if (!ctx.req._datadog) ctx.req._datadog = {};
-          ctx.req._datadog = { span: span.context()._trace.started[0] };
-        }
-      },
       ...config.datadog
     });
   }

--- a/src/initializers/datadog/index.ts
+++ b/src/initializers/datadog/index.ts
@@ -5,10 +5,16 @@ let tracer;
 export default config => {
   if (process.env.DD_SERVICE && process.env.DD_ENV) {
     tracer = requireInjected('dd-trace').init();
-    tracer.use('http', { client: false })
+    tracer.use('http', { client: false });
     tracer.use('koa', {
       blacklist: config?.datadog?.blacklistedPaths,
       blocklist: config?.datadog?.blacklistedPaths,
+      hooks: {
+        request: (span, ctx) => {
+          getLogger('orka.initializers.datadog').info(`ctx.req: ${JSON.stringify(ctx.req)}`);
+          if (!ctx.req._datadog) ctx.request = { _datadog: span };
+        }
+      },
       ...config.datadog
     });
   }

--- a/src/initializers/datadog/index.ts
+++ b/src/initializers/datadog/index.ts
@@ -11,7 +11,6 @@ export default config => {
       blocklist: config?.datadog?.blacklistedPaths,
       hooks: {
         request: (span, ctx) => {
-          getLogger('orka.initializers.datadog').info(`ctx: ${JSON.stringify(ctx)}`);
           getLogger('orka.initializers.datadog').info(`ctx.req: ${JSON.stringify(ctx.req)}`);
           getLogger('orka.initializers.datadog').info(`ctx.request: ${JSON.stringify(ctx.request)}`);
           if (!ctx.req?._datadog) ctx.req = { _datadog: span };

--- a/src/initializers/datadog/index.ts
+++ b/src/initializers/datadog/index.ts
@@ -11,8 +11,10 @@ export default config => {
       blocklist: config?.datadog?.blacklistedPaths,
       hooks: {
         request: (span, ctx) => {
+          getLogger('orka.initializers.datadog').info(`ctx: ${JSON.stringify(ctx)}`);
           getLogger('orka.initializers.datadog').info(`ctx.req: ${JSON.stringify(ctx.req)}`);
-          if (!ctx.req._datadog) ctx.request = { _datadog: span };
+          getLogger('orka.initializers.datadog').info(`ctx.request: ${JSON.stringify(ctx.request)}`);
+          if (!ctx.req?._datadog) ctx.req = { _datadog: span };
         }
       },
       ...config.datadog

--- a/src/initializers/koa/add-request-context.ts
+++ b/src/initializers/koa/add-request-context.ts
@@ -1,21 +1,26 @@
 import { AsyncLocalStorage } from 'async_hooks';
 import { Context, Middleware } from 'koa';
 import { pick } from 'lodash';
+import { getRootSpan } from '../../helpers';
 
-export default function(als: AsyncLocalStorage<Map<string, any>>, config): Middleware {
+export default function (als: AsyncLocalStorage<Map<string, any>>, config): Middleware {
   return async function addRequestContext(ctx: Context, next: () => Promise<void>) {
     const store = new Map<string, any>();
     return als.run(store, () => {
       if (ctx.state.requestId) {
         store.set('requestId', ctx.state.requestId);
       }
-      if (ctx.req?._datadog?.span) {
-        store.set('ddSpan', ctx.req._datadog.span);
+
+      const span = getRootSpan(ctx);
+      if (span) {
+        store.set('ddSpan', span);
       }
+
       if (config.requestContext.istioTraceContextHeaders.enabled) {
         const istioHeaders = pick(ctx.headers, config.requestContext.istioTraceContextHeaders.headers);
         store.set('istio-headers', istioHeaders);
       }
+
       return next();
     });
   };

--- a/src/middlewares/datadog-match-routes.ts
+++ b/src/middlewares/datadog-match-routes.ts
@@ -1,8 +1,13 @@
 import { Context } from 'koa';
+import { getDatadogTracer } from './../initializers/datadog/index';
 
 export default async function matchedRoute(ctx: Context, next: () => Promise<void>) {
   if (ctx._matchedRoute) {
-    const ddSpan = ctx.req?._datadog?.span;
+    // const ddSpan = ctx.req?._datadog?.span;
+    const span = getDatadogTracer().scope().active();
+    let ddSpan;
+    if (span) ddSpan = span.context()._trace.started[0];
+
     if (ddSpan) {
       ddSpan.setTag('resource.name', `${ctx.request.method} ${ctx._matchedRoute}`);
       ddSpan.setTag('matchedRoute', ctx._matchedRoute);

--- a/src/middlewares/datadog-match-routes.ts
+++ b/src/middlewares/datadog-match-routes.ts
@@ -1,12 +1,9 @@
 import { Context } from 'koa';
-import { getDatadogTracer } from './../initializers/datadog/index';
+import { getRootSpan } from '../helpers';
 
 export default async function matchedRoute(ctx: Context, next: () => Promise<void>) {
   if (ctx._matchedRoute) {
-    // const ddSpan = ctx.req?._datadog?.span;
-    const span = getDatadogTracer().scope().active();
-    let ddSpan;
-    if (span) ddSpan = span.context()._trace.started[0];
+    const ddSpan = getRootSpan(ctx);
 
     if (ddSpan) {
       ddSpan.setTag('resource.name', `${ctx.request.method} ${ctx._matchedRoute}`);

--- a/test/helpers/get-root-span.test.ts
+++ b/test/helpers/get-root-span.test.ts
@@ -7,6 +7,16 @@ import * as datadog from '../../src/initializers/datadog/index';
 const sandbox = sinon.createSandbox();
 
 describe('Test get-root-span helper', function () {
+  before(function () {
+    process.env.DD_SERVICE = 'true';
+    process.env.DD_ENV = 'true';
+  });
+
+  after(function () {
+    delete process.env.DD_SERVICE;
+    delete process.env.DD_ENV;
+  });
+
   afterEach(function () {
     sandbox.restore();
   });

--- a/test/helpers/get-root-span.test.ts
+++ b/test/helpers/get-root-span.test.ts
@@ -1,0 +1,64 @@
+import * as sinon from 'sinon';
+import { Context } from 'koa';
+import { default as getRootSpan } from '../../src/helpers/get-root-span';
+import should = require('should');
+import * as datadog from '../../src/initializers/datadog/index';
+
+const sandbox = sinon.createSandbox();
+
+describe.only('Test get-root-span helper', function () {
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  describe('Test dd-trace until v2.2.0 with _datadog property', function () {
+    it('should return span from req._datadog', function () {
+      const stub = sandbox.stub();
+      const ctx = ({
+        req: { _datadog: { span: { value: 'mySpan' } } },
+        request: { method: 'GET' }
+      } as unknown) as Context;
+
+      const span = getRootSpan(ctx);
+      span.value.should.equal('mySpan');
+    });
+  });
+
+  describe('Test dd-trace > v2.2.0 without _datadog property', function () {
+    it('should return undefined if getDatadogTracer does not exist', function () {
+      const ctx = ({ request: { method: 'GET' } } as unknown) as Context;
+      const span = getRootSpan(ctx);
+      should(span).be.undefined();
+    });
+
+    it('should return undefined if started array is empty', function () {
+      const tracerStub = {
+        scope: sandbox.stub().returns({
+          active: sandbox.stub().returns({
+            context: sandbox.stub().returns({ _trace: { started: [] } })
+          })
+        })
+      };
+      sandbox.stub(datadog, 'getDatadogTracer').returns(tracerStub as any);
+
+      const ctx = ({ request: { method: 'GET' } } as unknown) as Context;
+      const span = getRootSpan(ctx);
+      should(span).be.undefined();
+    });
+
+    it('should return span from started array first value', function () {
+      const tracerStub = {
+        scope: sandbox.stub().returns({
+          active: sandbox.stub().returns({
+            context: sandbox.stub().returns({ _trace: { started: [{ value: 'mySpan' }, { value: 'test' }] } })
+          })
+        })
+      };
+      sandbox.stub(datadog, 'getDatadogTracer').returns(tracerStub as any);
+
+      const ctx = ({ request: { method: 'GET' } } as unknown) as Context;
+      const span = getRootSpan(ctx);
+      span.value.should.equal('mySpan');
+    });
+  });
+});

--- a/test/helpers/get-root-span.test.ts
+++ b/test/helpers/get-root-span.test.ts
@@ -1,4 +1,5 @@
 import * as sinon from 'sinon';
+import * as log4js from 'log4js';
 import { Context } from 'koa';
 import { default as getRootSpan } from '../../src/helpers/get-root-span';
 import should = require('should');
@@ -69,6 +70,24 @@ describe('Test get-root-span helper', function () {
       const ctx = ({ request: { method: 'GET' } } as unknown) as Context;
       const span = getRootSpan(ctx);
       span.value.should.equal('mySpan');
+    });
+
+    it('should log warning if tracer api changes', function () {
+      const tracerStub = {
+        newScope: sandbox.stub().returns({
+          active: sandbox.stub().returns({
+            context: sandbox.stub().returns({ _trace: { started: [{ value: 'mySpan' }, { value: 'test' }] } })
+          })
+        })
+      };
+      sandbox.stub(datadog, 'getDatadogTracer').returns(tracerStub as any);
+      const loggerStub = sandbox.stub(log4js.getLogger('orka.helpers.get-root-span').constructor.prototype, 'error');
+
+      const ctx = ({ request: { method: 'GET' } } as unknown) as Context;
+      const span = getRootSpan(ctx);
+
+      loggerStub.calledOnce.should.be.true();
+      loggerStub.args[0][0].should.containEql('dd-trace error trying to find root span');
     });
   });
 });

--- a/test/helpers/get-root-span.test.ts
+++ b/test/helpers/get-root-span.test.ts
@@ -6,7 +6,7 @@ import * as datadog from '../../src/initializers/datadog/index';
 
 const sandbox = sinon.createSandbox();
 
-describe.only('Test get-root-span helper', function () {
+describe('Test get-root-span helper', function () {
   afterEach(function () {
     sandbox.restore();
   });

--- a/test/helpers/get-root-span.test.ts
+++ b/test/helpers/get-root-span.test.ts
@@ -87,7 +87,7 @@ describe('Test get-root-span helper', function () {
       const span = getRootSpan(ctx);
 
       loggerStub.calledOnce.should.be.true();
-      loggerStub.args[0][0].should.containEql('dd-trace error trying to find root span');
+      loggerStub.args[0][1].should.containEql('dd-trace error trying to find root span');
     });
   });
 });


### PR DESCRIPTION
Currently orka (and all our apps) work with dd-trace until version 2.2.0.

This is because dd-trace library deprecated (private) property req._datadog we use ([example](https://github.com/Workable/orka/blob/c915badf5793da3db516c1d5a2f98d0e1d6ca816/src/middlewares/datadog-match-routes.ts#L5)) to get the root span.

Here are the respective changes between versions [2.2.0](https://github.com/DataDog/dd-trace-js/blob/4a096167f4b5168186df9324f4a4a1364ce12f87/packages/dd-trace/src/plugins/util/web.js#L161) and [2.2.1](https://github.com/DataDog/dd-trace-js/blob/a331be34e1ed3b2b8461a4993e425e107f12664a/packages/dd-trace/src/plugins/util/web.js#L169) in dd-trace that caused our implementation to stop working if we bump (tested in prisma)

SRE team asked for a version > 2.15.0 that supports an environment variable they want to use. 

After a lot of testing, the only workaround found is based on this [issue](https://github.com/DataDog/dd-trace-js/issues/725) that asks for the exact same span we need (fun fact is that it is [implemented in helper method of dd-trace](https://github.com/DataDog/dd-trace-js/blob/b78ebaaea3e4857b4de3cd4112d0d9ed2c2f6730/packages/dd-trace/src/plugins/util/web.js#L251) library but unfortunately not exposed in api)

New orka helper is tested in prisma with dd-trace versions 1.7.1, 2.20.0, 3.9.3 and seems to work as expected. In the screenshot above there are requests with version 3.9.3 (at 14:17) and 1.7.1 (at 14:44). [Here](https://app.datadoghq.com/apm/traces?query=%40_top_level%3A1%20env%3Aofficedroid%20service%3Aprisma%20operation_name%3Akoa.request&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&historicalData=true&messageDisplay=inline&sort=desc&spanType=service-entry&start=1672228628846&end=1672232228846&paused=false) is the link of DD (it traces are still available)

![image](https://user-images.githubusercontent.com/3462758/209815743-ef2866cc-c515-4a64-b722-176f26e87c65.png)

![image](https://user-images.githubusercontent.com/3462758/209816098-8c4dce0e-07b1-40e2-98bc-1aaa3d51e26e.png)

Before the fix, even the url wasn't available in resource.
