### PR TITLE
Expose pg pool configuration to apps

### DIFF
--- a/__snapshots__/diamorphosis.test.ts.js
+++ b/__snapshots__/diamorphosis.test.ts.js
@@ -170,6 +170,8 @@ exports['Diamorphosis Test should set json/console loggingvariables when nothing
     "url": "",
     "poolSize": 50,
     "useSsl": true,
+    "idleTimeoutMillis": 10000,
+    "connectionTimeoutMillis": 0,
     "sslConfig": {
       "rejectUnauthorized": false,
       "ca": "",
@@ -377,6 +379,8 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
     "url": "",
     "poolSize": 50,
     "useSsl": true,
+    "idleTimeoutMillis": 10000,
+    "connectionTimeoutMillis": 0,
     "sslConfig": {
       "rejectUnauthorized": false,
       "ca": "",
@@ -584,6 +588,8 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
     "url": "",
     "poolSize": 50,
     "useSsl": true,
+    "idleTimeoutMillis": 10000,
+    "connectionTimeoutMillis": 0,
     "sslConfig": {
       "rejectUnauthorized": false,
       "ca": "",
@@ -791,6 +797,8 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
     "url": "",
     "poolSize": 50,
     "useSsl": true,
+    "idleTimeoutMillis": 10000,
+    "connectionTimeoutMillis": 0,
     "sslConfig": {
       "rejectUnauthorized": false,
       "ca": "",
@@ -998,6 +1006,8 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
     "url": "",
     "poolSize": 50,
     "useSsl": true,
+    "idleTimeoutMillis": 10000,
+    "connectionTimeoutMillis": 0,
     "sslConfig": {
       "rejectUnauthorized": false,
       "ca": "",
@@ -1210,6 +1220,8 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
     "url": "",
     "poolSize": 50,
     "useSsl": true,
+    "idleTimeoutMillis": 10000,
+    "connectionTimeoutMillis": 0,
     "sslConfig": {
       "rejectUnauthorized": false,
       "ca": "",
@@ -1424,6 +1436,8 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
     "url": "",
     "poolSize": 50,
     "useSsl": true,
+    "idleTimeoutMillis": 10000,
+    "connectionTimeoutMillis": 0,
     "sslConfig": {
       "rejectUnauthorized": false,
       "ca": "",

--- a/docs/integrations/postgres.md
+++ b/docs/integrations/postgres.md
@@ -37,12 +37,23 @@ eg:
 
 module.exports = {
   postgres: {
-    url: 'postgres://localhost:5432/orka_development'
+    url: 'postgres://localhost:5432/orka_development',
+    // default values used below. Only include them to overwrite them
+    poolSize: 50,
+    useSsl: true,
+    idleTimeoutMillis: 10000,
+    connectionTimeoutMillis: 0,
+    sslConfig: {
+      rejectUnauthorized: false,
+      ca: '',
+      cert: '',
+      key: '',
   }
-}
+};
 ```
 
 If don't need to support ssl
+
 ```js
 //config/config.js
 
@@ -51,7 +62,7 @@ module.exports = {
     url: 'postgres://localhost:5432/orka_development',
     useSsl: false
   }
-}
+};
 ```
 
 For more information about ssl support look at [node-postgres docs](https://node-postgres.com/features/ssl).
@@ -61,23 +72,25 @@ For more information about ssl support look at [node-postgres docs](https://node
 You can call `getPostgresPool` to acquire a new client to communicate with the database.
 
 If you choose to run `client = await pool.connect()` you should ALWAYS release the client using `client.release()` after finishing your operations.
+
 ```js
-const {getPostgresPool} = require('@workablehr/orka');
+const { getPostgresPool } = require('@workablehr/orka');
 
 const client = await getPostgresPool().connect();
 try {
-  const res = await client.query('SELECT * FROM users WHERE id = $1', [1])
-  console.log(res.rows[0])
+  const res = await client.query('SELECT * FROM users WHERE id = $1', [1]);
+  console.log(res.rows[0]);
 } finally {
   // Make sure to release the client before any error handling,
   // just in case the error handling itself throws an error.
-  client.release()
+  client.release();
 }
 ```
+
 Alternatively, you can use `pool.query` for single queries.
 
 ```js
-const {getPostgresPool} = require('@workablehr/orka');
+const { getPostgresPool } = require('@workablehr/orka');
 
 const pool = getPostgresPool();
 const results = await pool.query('SELECT NOW() as now');
@@ -88,7 +101,7 @@ const results = await pool.query('SELECT NOW() as now');
 Orka also provides a transaction wrapper that handles begin, commit & rollback of a transaction if something fails. In addition, it releases the client uppon completion
 
 ```js
-const {withPostgresTransaction} = require('@workablehr/orka');
+const { withPostgresTransaction } = require('@workablehr/orka');
 
 const callback = async c => {
   await c.query('INSERT INTO users VALUES(1, "orka user")');
@@ -96,5 +109,4 @@ const callback = async c => {
 };
 
 await withPostgresTransaction(callback);
-
 ```

--- a/src/initializers/diamorphosis.ts
+++ b/src/initializers/diamorphosis.ts
@@ -226,6 +226,8 @@ function addPostgresConfig(config) {
     url: '',
     poolSize: 50,
     useSsl: true,
+    idleTimeoutMillis: 10000,
+    connectionTimeoutMillis: 0,
     ...config.postgres,
     sslConfig: {
       rejectUnauthorized: false,

--- a/src/initializers/postgres.ts
+++ b/src/initializers/postgres.ts
@@ -18,7 +18,9 @@ export default function postgres(config) {
     pool = new Pool({
       connectionString: pgConfig.url,
       max: pgConfig.poolSize,
-      ssl: pgConfig.useSsl ? pgConfig.sslConfig : undefined
+      ssl: pgConfig.useSsl ? pgConfig.sslConfig : undefined,
+      idleTimeoutMillis: pgConfig.idleTimeoutMillis,
+      connectionTimeoutMillis: pgConfig.connectionTimeoutMillis
     });
     logger.info(`Connected to Postgres! (${pgConfig.url.split('@')[1] || pgConfig.url})`);
     pool.on('error', err => {

--- a/test/initializers/postgres.test.ts
+++ b/test/initializers/postgres.test.ts
@@ -50,7 +50,9 @@ describe('Test postgres connection', function () {
         {
           connectionString: 'postgres://localhost',
           max: undefined,
-          ssl: { rejectUnauthorized: false }
+          ssl: { rejectUnauthorized: false },
+          idleTimeoutMillis: undefined,
+          connectionTimeoutMillis: undefined
         }
       ]
     ]);
@@ -66,7 +68,9 @@ describe('Test postgres connection', function () {
           ca: '',
           cert: '',
           key: ''
-        }
+        },
+        idleTimeoutMillis: 10000,
+        connectionTimeoutMillis: 0
       }
     });
     poolStub.args.should.eql([
@@ -74,7 +78,9 @@ describe('Test postgres connection', function () {
         {
           connectionString: 'postgres://localhost',
           max: undefined,
-          ssl: undefined
+          ssl: undefined,
+          idleTimeoutMillis: 10000,
+          connectionTimeoutMillis: 0
         }
       ]
     ]);
@@ -90,7 +96,9 @@ describe('Test postgres connection', function () {
           ca: 'ca',
           cert: 'cert',
           key: 'key'
-        }
+        },
+        idleTimeoutMillis: 10000,
+        connectionTimeoutMillis: 0
       }
     });
     poolStub.args.should.eql([
@@ -103,7 +111,9 @@ describe('Test postgres connection', function () {
             ca: 'ca',
             cert: 'cert',
             key: 'key'
-          }
+          },
+          idleTimeoutMillis: 10000,
+          connectionTimeoutMillis: 0
         }
       ]
     ]);


### PR DESCRIPTION
Amazingly a client can be used in `pg` after it has been released. By default for [10seconds](https://node-postgres.com/apis/pool).
This has caused us a hard to find bug. Exposing the configuration with this pr so that this behaviour is easily tested and reproduced in tests.

CC @klesgidis 