### PR TITLE
Set logging in metrics optional

### DIFF
--- a/src/helpers/log-metrics.ts
+++ b/src/helpers/log-metrics.ts
@@ -22,11 +22,14 @@ const logMetrics = {
     const s = Number(ns) / 1e9;
     if (prometheusTimeEnabled()) logMetrics.prometheusEndClient().observe({ flow, flowType }, s);
     if (newRelicEnabled()) getNewRelic().recordMetric(`Custom/${flowType}/${flow}`, s);
+
     if (enableLog) logger.debug(`[${id}] TIME_LOGGING[${flowType}][${flow}] ${s.toFixed(3)} s`);
+    else logger.trace(`[${id}] TIME_LOGGING[${flowType}][${flow}] ${s.toFixed(3)} s`);
   },
 
   recordMetric(event: string, eventType: string, value: number, enableLog: boolean = true) {
     if (enableLog) logger.debug(`[${eventType}][${event}]: ${value}`);
+    else logger.trace(`[${eventType}][${event}]: ${value}`);
 
     if (newRelicEnabled()) getNewRelic().recordMetric('Custom/' + eventType + '/' + event, value);
     if (prometheusEventEnabled()) logMetrics.prometheusRecordMetricsClient().observe({ event, eventType }, value);

--- a/src/helpers/log-metrics.ts
+++ b/src/helpers/log-metrics.ts
@@ -17,18 +17,18 @@ const logMetrics = {
     return process.hrtime.bigint();
   },
 
-  end(start: bigint, flow: string, flowType: string, id: string, enableLog: boolean = true) {
+  end(start: bigint, flow: string, flowType: string, id: string, logLevelDebug: boolean = true) {
     const ns = process.hrtime.bigint() - start;
     const s = Number(ns) / 1e9;
     if (prometheusTimeEnabled()) logMetrics.prometheusEndClient().observe({ flow, flowType }, s);
     if (newRelicEnabled()) getNewRelic().recordMetric(`Custom/${flowType}/${flow}`, s);
 
-    if (enableLog) logger.debug(`[${id}] TIME_LOGGING[${flowType}][${flow}] ${s.toFixed(3)} s`);
+    if (logLevelDebug) logger.debug(`[${id}] TIME_LOGGING[${flowType}][${flow}] ${s.toFixed(3)} s`);
     else logger.trace(`[${id}] TIME_LOGGING[${flowType}][${flow}] ${s.toFixed(3)} s`);
   },
 
-  recordMetric(event: string, eventType: string, value: number, enableLog: boolean = true) {
-    if (enableLog) logger.debug(`[${eventType}][${event}]: ${value}`);
+  recordMetric(event: string, eventType: string, value: number, logLevelDebug: boolean = true) {
+    if (logLevelDebug) logger.debug(`[${eventType}][${event}]: ${value}`);
     else logger.trace(`[${eventType}][${event}]: ${value}`);
 
     if (newRelicEnabled()) getNewRelic().recordMetric('Custom/' + eventType + '/' + event, value);

--- a/src/helpers/log-metrics.ts
+++ b/src/helpers/log-metrics.ts
@@ -17,16 +17,16 @@ const logMetrics = {
     return process.hrtime.bigint();
   },
 
-  end(start: bigint, flow: string, flowType: string, id: string) {
+  end(start: bigint, flow: string, flowType: string, id: string, enableLog: boolean = true) {
     const ns = process.hrtime.bigint() - start;
     const s = Number(ns) / 1e9;
     if (prometheusTimeEnabled()) logMetrics.prometheusEndClient().observe({ flow, flowType }, s);
     if (newRelicEnabled()) getNewRelic().recordMetric(`Custom/${flowType}/${flow}`, s);
-    logger.debug(`[${id}] TIME_LOGGING[${flowType}][${flow}] ${s.toFixed(3)} s`);
+    if (enableLog) logger.debug(`[${id}] TIME_LOGGING[${flowType}][${flow}] ${s.toFixed(3)} s`);
   },
 
-  recordMetric(event: string, eventType: string, value: number) {
-    logger.debug(`[${eventType}][${event}]: ${value}`);
+  recordMetric(event: string, eventType: string, value: number, enableLog: boolean = true) {
+    if (enableLog) logger.debug(`[${eventType}][${event}]: ${value}`);
 
     if (newRelicEnabled()) getNewRelic().recordMetric('Custom/' + eventType + '/' + event, value);
     if (prometheusEventEnabled()) logMetrics.prometheusRecordMetricsClient().observe({ event, eventType }, value);

--- a/test/helpers/log-metrics.test.ts
+++ b/test/helpers/log-metrics.test.ts
@@ -6,7 +6,7 @@ import OrkaBuilder from '../../src/orka-builder';
 
 const sandbox = sinon.createSandbox();
 
-describe('Test log-metrics helper', function () {
+describe.only('Test log-metrics helper', function () {
   describe('Test start', function () {
     it('should return start as bigint', function () {
       const start = logMetrics.start();
@@ -57,7 +57,7 @@ describe('Test log-metrics helper', function () {
         delete process.env.NEW_RELIC_LICENSE_KEY;
       });
 
-      it('should not log debug and send to newRelic and prometheus if logLevelDebug: false', function () {
+      it('should log trace and send to newRelic and prometheus if logLevelDebug: false', function () {
         OrkaBuilder.INSTANCE = { config: { prometheus: { enabled: true, timeSummary: { enabled: true } } } } as any;
         process.env.NEW_RELIC_LICENSE_KEY = 'foo';
 
@@ -144,7 +144,7 @@ describe('Test log-metrics helper', function () {
         delete process.env.NEW_RELIC_LICENSE_KEY;
       });
 
-      it('should not log debug and send to newRelic and prometheus if logLevelDebug: false', function () {
+      it('should log trace and send to newRelic and prometheus if logLevelDebug: false', function () {
         OrkaBuilder.INSTANCE = { config: { prometheus: { enabled: true, eventSummary: { enabled: true } } } } as any;
         process.env.NEW_RELIC_LICENSE_KEY = 'foo';
 
@@ -173,10 +173,10 @@ describe('Test log-metrics helper', function () {
         loggerDebugStub.calledWith('[type][test]: 1').should.be.true();
       });
 
-      it('should not log debug if logLevelDebug: false', function () {
+      it('should log trace if logLevelDebug: false', function () {
         OrkaBuilder.INSTANCE = { config: { prometheus: { enabled: false } } } as any;
 
-        logMetrics.recordMetric('test', 'type', 1, );
+        logMetrics.recordMetric('test', 'type', 1, false);
 
         recordMetricSpy.called.should.be.false();
         observeSpy.called.should.be.false();

--- a/test/helpers/log-metrics.test.ts
+++ b/test/helpers/log-metrics.test.ts
@@ -18,9 +18,11 @@ describe('Test log-metrics helper', function () {
   describe('Test end', function () {
     let observeSpy;
     let recordMetricSpy;
-    let loggerStub;
+    let loggerDebugStub;
+    let loggerTraceStub;
     beforeEach(function () {
-      loggerStub = sandbox.stub(log4js.getLogger('orka.errorHandler').constructor.prototype, 'debug');
+      loggerDebugStub = sandbox.stub(log4js.getLogger('orka.errorHandler').constructor.prototype, 'debug');
+      loggerTraceStub = sandbox.stub(log4js.getLogger('orka.errorHandler').constructor.prototype, 'trace');
 
       observeSpy = sandbox.stub();
       sandbox.stub(logMetrics, 'prometheusEndClient').returns({
@@ -45,8 +47,8 @@ describe('Test log-metrics helper', function () {
         const start = logMetrics.start();
         logMetrics.end(start, 'name', 'type', 'corID');
 
-        loggerStub.calledOnce.should.be.true();
-        loggerStub.args[0][0].should.containEql('[corID] TIME_LOGGING[type][name]');
+        loggerDebugStub.calledOnce.should.be.true();
+        loggerDebugStub.args[0][0].should.containEql('[corID] TIME_LOGGING[type][name]');
         recordMetricSpy.calledOnce.should.be.true();
         recordMetricSpy.args[0][0].should.eql('Custom/type/name');
         observeSpy.calledOnce.should.be.true();
@@ -62,7 +64,9 @@ describe('Test log-metrics helper', function () {
         const start = logMetrics.start();
         logMetrics.end(start, 'name', 'type', 'corID', false);
 
-        loggerStub.calledOnce.should.be.false();
+        loggerDebugStub.calledOnce.should.be.false();
+        loggerTraceStub.calledOnce.should.be.true();
+        loggerTraceStub.args[0][0].should.containEql('[corID] TIME_LOGGING[type][name]');
         recordMetricSpy.calledOnce.should.be.true();
         recordMetricSpy.args[0][0].should.eql('Custom/type/name');
         observeSpy.calledOnce.should.be.true();
@@ -81,11 +85,11 @@ describe('Test log-metrics helper', function () {
 
         recordMetricSpy.called.should.be.false();
         observeSpy.called.should.be.false();
-        loggerStub.called.should.be.true();
-        loggerStub.args[0][0].should.containEql('[corID] TIME_LOGGING[type][name]');
+        loggerDebugStub.called.should.be.true();
+        loggerDebugStub.args[0][0].should.containEql('[corID] TIME_LOGGING[type][name]');
       });
 
-      it('should not log debug if enableLog: false', function () {
+      it('should log trace if enableLog: false', function () {
         OrkaBuilder.INSTANCE = { config: { prometheus: { enabled: true } } } as any;
 
         const start = logMetrics.start();
@@ -93,7 +97,9 @@ describe('Test log-metrics helper', function () {
 
         recordMetricSpy.called.should.be.false();
         observeSpy.called.should.be.false();
-        loggerStub.called.should.be.false();
+        loggerDebugStub.called.should.be.false();
+        loggerTraceStub.called.should.be.true();
+        loggerTraceStub.args[0][0].should.containEql('[corID] TIME_LOGGING[type][name]');
       });
     });
   });
@@ -101,9 +107,11 @@ describe('Test log-metrics helper', function () {
   describe('Test recordMetric', function () {
     let observeSpy;
     let recordMetricSpy;
-    let loggerStub;
+    let loggerDebugStub;
+    let loggerTraceStub;
     beforeEach(function () {
-      loggerStub = sandbox.stub(log4js.getLogger('orka.errorHandler').constructor.prototype, 'debug');
+      loggerDebugStub = sandbox.stub(log4js.getLogger('orka.errorHandler').constructor.prototype, 'debug');
+      loggerTraceStub = sandbox.stub(log4js.getLogger('orka.errorHandler').constructor.prototype, 'trace');
 
       observeSpy = sandbox.stub();
       sandbox.stub(logMetrics, 'prometheusRecordMetricsClient').returns({
@@ -129,8 +137,8 @@ describe('Test log-metrics helper', function () {
 
         recordMetricSpy.called.should.be.true();
         recordMetricSpy.calledWith('Custom/type/test', 1).should.be.true();
-        loggerStub.calledOnce.should.be.true();
-        loggerStub.calledWith('[type][test]: 1').should.be.true();
+        loggerDebugStub.calledOnce.should.be.true();
+        loggerDebugStub.calledWith('[type][test]: 1').should.be.true();
         observeSpy.args[0].should.containDeep([{ event: 'test', eventType: 'type' }, 1]);
 
         delete process.env.NEW_RELIC_LICENSE_KEY;
@@ -144,7 +152,9 @@ describe('Test log-metrics helper', function () {
 
         recordMetricSpy.called.should.be.true();
         recordMetricSpy.calledWith('Custom/type/test', 1).should.be.true();
-        loggerStub.calledOnce.should.be.false();
+        loggerDebugStub.calledOnce.should.be.false();
+        loggerTraceStub.calledOnce.should.be.true();
+        loggerTraceStub.calledWith('[type][test]: 1').should.be.true();
         observeSpy.args[0].should.containDeep([{ event: 'test', eventType: 'type' }, 1]);
 
         delete process.env.NEW_RELIC_LICENSE_KEY;
@@ -159,8 +169,8 @@ describe('Test log-metrics helper', function () {
 
         recordMetricSpy.called.should.be.false();
         observeSpy.called.should.be.false();
-        loggerStub.called.should.be.true();
-        loggerStub.calledWith('[type][test]: 1').should.be.true();
+        loggerDebugStub.called.should.be.true();
+        loggerDebugStub.calledWith('[type][test]: 1').should.be.true();
       });
 
       it('should not log debug if enableLog: false', function () {
@@ -170,7 +180,9 @@ describe('Test log-metrics helper', function () {
 
         recordMetricSpy.called.should.be.false();
         observeSpy.called.should.be.false();
-        loggerStub.called.should.be.false();
+        loggerDebugStub.called.should.be.false();
+        loggerTraceStub.called.should.be.true();
+        loggerTraceStub.calledWith('[type][test]: 1').should.be.true();
       });
     });
   });

--- a/test/helpers/log-metrics.test.ts
+++ b/test/helpers/log-metrics.test.ts
@@ -57,7 +57,7 @@ describe('Test log-metrics helper', function () {
         delete process.env.NEW_RELIC_LICENSE_KEY;
       });
 
-      it('should not log debug and send to newRelic and prometheus if enableLog: false', function () {
+      it('should not log debug and send to newRelic and prometheus if logLevelDebug: false', function () {
         OrkaBuilder.INSTANCE = { config: { prometheus: { enabled: true, timeSummary: { enabled: true } } } } as any;
         process.env.NEW_RELIC_LICENSE_KEY = 'foo';
 
@@ -89,7 +89,7 @@ describe('Test log-metrics helper', function () {
         loggerDebugStub.args[0][0].should.containEql('[corID] TIME_LOGGING[type][name]');
       });
 
-      it('should log trace if enableLog: false', function () {
+      it('should log trace if logLevelDebug: false', function () {
         OrkaBuilder.INSTANCE = { config: { prometheus: { enabled: true } } } as any;
 
         const start = logMetrics.start();
@@ -144,7 +144,7 @@ describe('Test log-metrics helper', function () {
         delete process.env.NEW_RELIC_LICENSE_KEY;
       });
 
-      it('should not log debug and send to newRelic and prometheus if enableLog: false', function () {
+      it('should not log debug and send to newRelic and prometheus if logLevelDebug: false', function () {
         OrkaBuilder.INSTANCE = { config: { prometheus: { enabled: true, eventSummary: { enabled: true } } } } as any;
         process.env.NEW_RELIC_LICENSE_KEY = 'foo';
 
@@ -173,10 +173,10 @@ describe('Test log-metrics helper', function () {
         loggerDebugStub.calledWith('[type][test]: 1').should.be.true();
       });
 
-      it('should not log debug if enableLog: false', function () {
+      it('should not log debug if logLevelDebug: false', function () {
         OrkaBuilder.INSTANCE = { config: { prometheus: { enabled: false } } } as any;
 
-        logMetrics.recordMetric('test', 'type', 1, false);
+        logMetrics.recordMetric('test', 'type', 1, );
 
         recordMetricSpy.called.should.be.false();
         observeSpy.called.should.be.false();


### PR DESCRIPTION
The purpose of this PR is to allow each application using logMetrics to define if it will log TIME_LOGGING message apart from sending it to DD.
