### PR TITLE
Propagate white-listed headers on  request context to subsequent calls

### DIFF
--- a/__snapshots__/diamorphosis.test.ts.js
+++ b/__snapshots__/diamorphosis.test.ts.js
@@ -201,6 +201,12 @@ exports['Diamorphosis Test should set json/console loggingvariables when nothing
         "x-b3-flags",
         "x-ot-span-context"
       ]
+    },
+    "headerPropagation": {
+      "enabled": true,
+      "headers": [
+        "cf-ray"
+      ]
     }
   }
 }
@@ -409,6 +415,12 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
         "x-b3-sampled",
         "x-b3-flags",
         "x-ot-span-context"
+      ]
+    },
+    "headerPropagation": {
+      "enabled": true,
+      "headers": [
+        "cf-ray"
       ]
     }
   }
@@ -619,6 +631,12 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
         "x-b3-flags",
         "x-ot-span-context"
       ]
+    },
+    "headerPropagation": {
+      "enabled": true,
+      "headers": [
+        "cf-ray"
+      ]
     }
   }
 }
@@ -828,6 +846,12 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
         "x-b3-flags",
         "x-ot-span-context"
       ]
+    },
+    "headerPropagation": {
+      "enabled": true,
+      "headers": [
+        "cf-ray"
+      ]
     }
   }
 }
@@ -1036,6 +1060,12 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
         "x-b3-sampled",
         "x-b3-flags",
         "x-ot-span-context"
+      ]
+    },
+    "headerPropagation": {
+      "enabled": true,
+      "headers": [
+        "cf-ray"
       ]
     }
   }
@@ -1250,6 +1280,12 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
         "x-b3-sampled",
         "x-b3-flags",
         "x-ot-span-context"
+      ]
+    },
+    "headerPropagation": {
+      "enabled": true,
+      "headers": [
+        "cf-ray"
       ]
     }
   }
@@ -1466,6 +1502,12 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
         "x-b3-sampled",
         "x-b3-flags",
         "x-ot-span-context"
+      ]
+    },
+    "headerPropagation": {
+      "enabled": true,
+      "headers": [
+        "cf-ray"
       ]
     }
   }

--- a/docs/request-context.md
+++ b/docs/request-context.md
@@ -39,6 +39,16 @@ By default orka propagates the following Istio headers:
 
 This list can be modified by changing `config.requestContext.istioTraceContextHeaders.headers`.
 
+### Header Propagation
+Cloudflare headers are appended to the context by default as long as the current nodejs version supports AsyncLocalStorage (async_hooks).
+
+If option `config.request.headerPropagation` is enabled, orka propagates any header specified in its whitelist.
+
+By default the following headers are propagated:
+- cf-ray
+
+The whitelist can be overriden by changing `config.requestContext.headerPropagation.headers` value.
+
 ### Configuration
 
 If you don't specify anything in your `config.requestContext` it defaults to:
@@ -51,6 +61,10 @@ If you don't specify anything in your `config.requestContext` it defaults to:
     "istioTraceContextHeaders": {
       "enabled": true,
       "headers": ["x-request-id", "x-b3-traceid", "x-b3-spanid", "x-b3-parentspanid", "x-b3-sampled", "x-b3-flags", "x-ot-span-context"]
+    },
+    "headerPropagation": {
+      "enabled": true,
+      "headers": ["cf-ray"]
     }
   }
 }

--- a/src/initializers/diamorphosis.ts
+++ b/src/initializers/diamorphosis.ts
@@ -123,6 +123,13 @@ export default (config, orkaOptions: Partial<OrkaOptions>) => {
       ],
       ...config.requestContext?.istioTraceContextHeaders
     },
+    headerPropagation: {
+      enabled: true,
+      headers: [
+        'cf-ray'
+      ],
+      ...config.requestContext?.headerPropagation
+    },
     ...config.requestContext
   };
   diamorphosis(orkaOptions.diamorphosis);

--- a/src/initializers/koa/add-request-context.ts
+++ b/src/initializers/koa/add-request-context.ts
@@ -3,7 +3,7 @@ import { Context, Middleware } from 'koa';
 import { pick } from 'lodash';
 import { getRootSpan } from '../../helpers';
 
-export default function (als: AsyncLocalStorage<Map<string, any>>, config): Middleware {
+export default function(als: AsyncLocalStorage<Map<string, any>>, config): Middleware {
   return async function addRequestContext(ctx: Context, next: () => Promise<void>) {
     const store = new Map<string, any>();
     return als.run(store, () => {
@@ -19,6 +19,11 @@ export default function (als: AsyncLocalStorage<Map<string, any>>, config): Midd
       if (config.requestContext.istioTraceContextHeaders.enabled) {
         const istioHeaders = pick(ctx.headers, config.requestContext.istioTraceContextHeaders.headers);
         store.set('istio-headers', istioHeaders);
+      }
+
+      if (config.requestContext.headerPropagation.enabled) {
+        const propagatedHeaders = pick(ctx.headers, config.requestContext.headerPropagation.headers);
+        store.set('propagated-headers', propagatedHeaders);
       }
 
       return next();

--- a/src/initializers/riviere.ts
+++ b/src/initializers/riviere.ts
@@ -70,6 +70,11 @@ const init = (config, orkaOptions) => {
             const istioTraceContextHeaders = getRequestContext()?.get('istio-headers');
             Object.assign(requestArgs.headers, istioTraceContextHeaders);
           }
+
+          if (config.requestContext.headerPropagation.enabled) {
+            Object.assign(requestArgs.headers, getRequestContext()?.get('propagated-headers'));
+          }
+
         } catch (e) {
           getLogger('orka.riviere').error(e);
         }


### PR DESCRIPTION
In order to propagate 'cf-ray' header to subsequent calls as requested here https://workable.atlassian.net/browse/PROD-20907

provided a generalised functionality for each application to define which headers can be propagated for logging.