### PR TITLE
More granular honeybadger error fingerprint

### DIFF
--- a/src/initializers/log4js/honeybadger-appender.ts
+++ b/src/initializers/log4js/honeybadger-appender.ts
@@ -34,6 +34,8 @@ function notifyHoneybadger(categoryName, error, ...rest) {
 
   const computedComponent = component || categoryName;
 
+  const fingerprint = generateFingerprint(name, computedComponent, action) || categoryName;
+
   Honeybadger.notify(
     { stack: error.stack, message, name },
     {
@@ -45,10 +47,22 @@ function notifyHoneybadger(categoryName, error, ...rest) {
       action,
       component: computedComponent,
       params,
-      fingerprint: action && computedComponent ? `${computedComponent}_${action}` : categoryName
+      fingerprint
     }
   );
 }
+
+const generateFingerprint = (name, component, action) => {
+  if (!action || !component) {
+    return;
+  }
+
+  if (name && name !== 'Error') {
+    return `${name}_${component}_${action}`;
+  } else {
+    return `${component}_${action}`;
+  }
+};
 
 const honeyBadgerAppender = () => {
   return logEvent => {

--- a/src/initializers/log4js/honeybadger-appender.ts
+++ b/src/initializers/log4js/honeybadger-appender.ts
@@ -34,7 +34,8 @@ function notifyHoneybadger(categoryName, error, ...rest) {
 
   const computedComponent = component || categoryName;
 
-  const fingerprint = generateFingerprint(name, computedComponent, action) || categoryName;
+  const fingerprint = context.fingerprint || generateFingerprint(name, computedComponent, action) || categoryName;
+  delete context.fingerprint;
 
   Honeybadger.notify(
     { stack: error.stack, message, name },

--- a/test/initializers/log4js/honeybadger-appender.test.ts
+++ b/test/initializers/log4js/honeybadger-appender.test.ts
@@ -125,6 +125,22 @@ describe('log4js_honeybadger_appender', () => {
     notifySpy.args[0][1].fingerprint.should.equal('CustomError_testController_/test/endpoint');
   });
 
+  it('should use fingerprint from context if it exists', () => {
+    const err = new Error('omg') as any;
+    err.status = 200;
+    err.component = 'testController';
+    err.action = '/test/endpoint';
+    appender.configure()({
+      level: {
+        level: 40000
+      },
+      categoryName: 'testCategoryName',
+      data: [err, {fingerprint: 'CustomError'}]
+    });
+    notifySpy.callCount.should.equal(1);
+    notifySpy.args[0][1].fingerprint.should.equal('CustomError');
+  });
+
   it('should append to the error message any additional string parameters', () => {
     const err = new Error('omg') as any;
     err.status = 200;

--- a/test/initializers/log4js/honeybadger-appender.test.ts
+++ b/test/initializers/log4js/honeybadger-appender.test.ts
@@ -99,6 +99,30 @@ describe('log4js_honeybadger_appender', () => {
       data: err
     });
     notifySpy.callCount.should.equal(1);
+    notifySpy.args[0][1].fingerprint.should.equal('testController_/test/endpoint');
+  });
+
+  it('should compute the fingerprint using the error name', () => {
+    class CustomError extends Error {
+      constructor(message) {
+        super(message);
+        this.name = 'CustomError';
+      }
+    }
+
+    const err = new CustomError('omg') as any;
+    err.status = 200;
+    err.component = 'testController';
+    err.action = '/test/endpoint';
+    appender.configure()({
+      level: {
+        level: 40000
+      },
+      categoryName: 'testCategoryName',
+      data: err
+    });
+    notifySpy.callCount.should.equal(1);
+    notifySpy.args[0][1].fingerprint.should.equal('CustomError_testController_/test/endpoint');
   });
 
   it('should append to the error message any additional string parameters', () => {


### PR DESCRIPTION
This PR implements two ways for orka applications to customise the error fingerprint and achieve more granular error grouping in honeybadger.

1. Errors with custom error.name will use that name as part of the generated fingerprint, e.g.

```js
err = new Error("foo");
err.name = "FooError";
throw err;
```

2. Manually passing a custom fingerprint from the error handler context will override the generated fingerprint, e.g.

```js
const errorHandler =  (ctx, err) => [err, {fingerprint: err.message}];
orka({
  // ...
  errorHandler
}).start();
```

Resolves https://github.com/Workable/orka/issues/346