### PR TITLE
[PROD-32442] prevent ssrf attacks for own S3 urls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@google-cloud/debug-agent": "^5.2.8",
-        "@workablehr/riviere": "^1.16.1",
+        "@workablehr/riviere": "*",
         "chalk": "^2.4.2",
         "codependency": "^2.1.0",
         "diamorphosis": "^0.8.3",

--- a/src/initializers/joi.ts
+++ b/src/initializers/joi.ts
@@ -7,10 +7,18 @@ export const isValidPhone = (val: string): boolean => /^[\d\s\(\)\-\+–\.]+$/.t
 export const clearNullByte = (val: string): string => (val && isString(val) ? val.replace(/\u0000/g, '') : val);
 export const isValidHexColor = (val: string): boolean => /^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/.test(val);
 export const isOwnS3Path = (bucket: string, val: string): boolean => {
-  const { origin, pathname } = new URL(val);
-  val = `${origin}${pathname}`;
-  return val?.startsWith(`https://${bucket}.s3.amazonaws.com`) ||
-  new RegExp(`^https:\\/\\/s3\\..+\\.amazonaws\\.com\\/${bucket}\\/.*`, 'g').test(val);
+  try {
+    const { host, protocol, pathname } = new URL(val);
+    const matchingProtocol = protocol === 'https:';
+    const s3Host = host === `${bucket}.s3.amazonaws.com`;
+    const s3HostBucketInPath =
+      host.startsWith('s3.') &&
+      host.endsWith('.amazonaws.com') &&
+      pathname.startsWith(`/${bucket}/`);
+    return matchingProtocol && (s3Host || s3HostBucketInPath);
+  } catch (e) {
+    return false;
+  }
 };
 
 export const isExpiredUrl = (val: string): boolean => {

--- a/src/initializers/joi.ts
+++ b/src/initializers/joi.ts
@@ -51,7 +51,7 @@ type UrlInOwnS3 = _Joi.StringSchema & {
   errorOnExpiredUrl: () => UrlInOwnS3;
 };
 
-interface JoiWithExtensions extends _Joi.Root {
+export interface JoiWithExtensions extends _Joi.Root {
   booleanWithEmpty(): _Joi.BooleanSchema;
 
   dateInThePast(): _Joi.DateSchema;

--- a/test/initializers/joi.test.ts
+++ b/test/initializers/joi.test.ts
@@ -134,6 +134,19 @@ describe('joi extensions', function () {
         underTest.error.message.should.equal('Invalid path provided');
       });
     });
+    it('s3 url with malicious domain should throw error', function () {
+      const urls = [
+        'https://workable-application-form.s3.amazonaws.com.ngrok.app/tmp/123-456-789',
+        'https://workable-application-form.s3.amazonaws.com.malicious.io/tmp/123-456-789',
+        'https://workable-application-form.s3.amazonaws.comattackerdomain.ly/tmp/123-456-789',
+        'https://s3.maliciousurl.maliciousamazonaws.com./workable-application-form/tmp/123-456-789',
+      ];
+
+      urls.forEach(url => {
+        const underTest = Joi.urlInOwnS3().bucket('workable-application-form').validate(url);
+        underTest.error.message.should.equal('Invalid path provided');
+      });
+    });
   });
   describe('url', function () {
     it('rejects URLs with less than two domain fragments', function () {


### PR DESCRIPTION
Prevent SSRF attacks in `isOwnS3Urls`.
Also replaced regex checking for s3 hosts with bucket in pathname, to be done using the `URL` attributes