### PR TITLE
Improved Kafka and RabbitMQ Functionality

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -73,3 +73,4 @@ ObjectId using new mongoose.
 - Support for older node version pre v18 is dropped. Only v18 and v20+ will be unit tested and guaranteed to work
 - Usage of randomUUID that is not supported in many older versions
 - Changes in default config: istioTraceHeaders and headerPropagation are deprecated in favor of a generic propagatedHeaders
+- Methods kafka.send that was deprecated is removed. Use kafka.producer.send instead

--- a/examples/kafka-example/config.js
+++ b/examples/kafka-example/config.js
@@ -6,11 +6,12 @@ module.exports = {
   log: {
     json: true
   },
+  traceHeaderName: 'x-request-id',
   kafka: {
     groupId: 'orka.example.pigasos',
     oldGroupId: 'orka.example.consumer',
     clientId: 'orka.example.producer',
-    brokers: ['localhost:9092'],
+    brokers: ['127.0.0.1:9092'],
     certificates: {
       ca: '',
       cert: '',

--- a/examples/kafka-example/handler.js
+++ b/examples/kafka-example/handler.js
@@ -1,10 +1,20 @@
 const { BaseKafkaHandler, getKafka } = require('../../build');
+const config = require('./config');
+const axios = require('axios');
 
 module.exports = class KafkaHandler extends BaseKafkaHandler {
   handle(message) {
-    console.log(message.headers);
-    console.log(message.value);
-    console.log(message);
+    console.log('key', message.key);
+    console.log('headers', message.headers);
+    console.log('message.value', message.value);
+    // console.log('message', message);
+    if (message.headers['x-depth'] >= 5) return;
+    this.get('write');
+  }
+
+  async get(path) {
+    const response = await axios.get(`http://localhost:${config.port}/${path}`);
+    return response.data;
   }
 };
 

--- a/examples/kafka-example/routes.js
+++ b/examples/kafka-example/routes.js
@@ -19,10 +19,16 @@ module.exports = {
       const config = require('./config');
       const kafka = getKafka();
       const topic = config.kafka.producer.topics.test;
-      await kafka.send(topic, JSON.stringify(input), null, null, [
-        { customHeaderKeyOne: 'customHeaderValueOne' },
-        { customHeaderKeyTwo: 'customHeaderValueTwo' }
-      ]);
+      await kafka.producer.send({
+        topic,
+        messages: [
+          {
+            key: 'foo',
+            value: JSON.stringify(input),
+            headers: { customHeaderKeyOne: 'customHeaderValueOne', customHeaderKeyTwo: 'customHeaderValueTwo' }
+          }
+        ]
+      });
     }
   }
 };

--- a/examples/rabbitmq-example/config.js
+++ b/examples/rabbitmq-example/config.js
@@ -7,7 +7,7 @@ module.exports = {
   traceHeaderName: 'x-request-id',
   queue: {
     prefetch: 100,
-    url: 'amqp://localhost',
+    url: 'amqp://127.0.0.1',
     frameMax: 0x1000,
     maxRetries: 0,
     retryDelay: 1000,

--- a/src/initializers/kafka/base-kafka-handler.ts
+++ b/src/initializers/kafka/base-kafka-handler.ts
@@ -74,7 +74,10 @@ abstract class Base<Input, Output> {
   }
 
   parseHeaders(headers: KafkajsType.IHeaders = {}) {
-    return Object.keys(headers).reduce((m, k) => ({ ...m, [k]: headers[k].toString() }), {});
+    return Object.keys(headers).reduce((m, k) => {
+      m[k] = headers[k].toString();
+      return m;
+    }, {});
   }
 
   transformToKafkaHandlerMessage(

--- a/src/initializers/kafka/index.ts
+++ b/src/initializers/kafka/index.ts
@@ -2,18 +2,55 @@ import { isEmpty } from 'lodash';
 import { KafkaConfig } from '../../typings/kafka';
 import Kafka from './kafka';
 import type * as KafkajsType from 'kafkajs';
+import { appendHeadersFromStore } from '../../utils';
+import { getRequestContext } from '../../builder';
+import { getLogger } from '../log4js';
 
-export { BaseKafkaHandler, BaseKafkaBatchHandler, BaseKafkaHandlerMessage, BaseKafkaHandlerOptions, BaseKafkaHandlerBatch } from './base-kafka-handler';
+let logger: ReturnType<typeof getLogger>;
+export {
+  BaseKafkaHandler,
+  BaseKafkaBatchHandler,
+  BaseKafkaHandlerMessage,
+  BaseKafkaHandlerOptions,
+  BaseKafkaHandlerBatch
+} from './base-kafka-handler';
 
 let kafka: Kafka;
-export default async (kafkaConfig: KafkaConfig, kafkaProducer?: KafkajsType.ProducerConfig) => {
+export default async (
+  config: { kafka: KafkaConfig; traceHeaderName: string },
+  kafkaProducer?: KafkajsType.ProducerConfig
+) => {
+  logger = getLogger('orka.kafka');
+  const kafkaConfig = config.kafka;
   if (!isEmpty(kafkaConfig && kafkaConfig.brokers)) {
     const Kafka = (await import('./kafka')).default;
 
     kafka = new Kafka(kafkaConfig);
     await kafka.connect(kafkaProducer);
+
+    updateSend(kafka, config);
   }
 };
+
+function updateSend(kafka: Kafka, config: { traceHeaderName: string }) {
+  const originalSend = kafka.producer.send;
+  kafka.producer.send = async function send(record) {
+    record.messages.forEach(message => {
+      const traceHeaderName = config.traceHeaderName.toLowerCase();
+      appendHeadersFromStore(message, getRequestContext(), config);
+      if (!message.key && message.headers[traceHeaderName]) {
+        message.key = message.headers[traceHeaderName];
+      }
+    });
+    const sent: KafkajsType.RecordMetadata[] = await originalSend.call(this, record);
+    sent.map((recordMetadata, i) =>
+      logger.debug(
+        `partition(${recordMetadata.partition}).offset(${recordMetadata.baseOffset}).key(${record.messages[i].key}) produced for topic ${recordMetadata.topicName}`
+      )
+    );
+    return sent;
+  };
+}
 
 export const getKafka = () => {
   if (!kafka) {

--- a/src/initializers/kafka/kafka.ts
+++ b/src/initializers/kafka/kafka.ts
@@ -3,7 +3,6 @@ import requireInjected from '../../require-injected';
 import { KafkaConfig } from '../../typings/kafka';
 import type * as KafkajsType from 'kafkajs';
 import { flatten, isEmpty } from 'lodash';
-import * as uuid from 'uuid';
 
 const { Kafka }: typeof KafkajsType = requireInjected('kafkajs');
 const logger = getLogger('orka.kafka');
@@ -163,30 +162,7 @@ export default class OrkaKafka {
     return responses;
   }
 
-  /**
-   * @deprecated  use producer.send instead which is native kafkajs send
-   */
-  public async send(
-    topic: string,
-    message: string | Buffer,
-    key: string = uuid.v4(),
-    partition?: number,
-    inputHeaders?: { [key: string]: string }[]
-  ) {
-    if (!key) key = uuid.v4();
-    const headers = inputHeaders?.reduce((m, h) => ({ ...m, ...h }), {});
-    const [recordMetadata] = await this.producer.send({
-      topic,
-      messages: [{ key, value: message, headers, partition }]
-    });
-    logger.debug('Deprecated method. Use getKafka().producer.send instead');
-    logger.info(
-      `partition(${recordMetadata.partition}).offset(${recordMetadata.baseOffset}).key(${key}) produced for topic ${topic}`
-    );
-    return recordMetadata;
-  }
-
-  private decideLogLevel = (message: string, level: string) => {
+  private decideLogLevel(message: string, level: string) {
     if (this.options.log.errorToWarn.includes(message) && level === 'error') {
       return 'warn';
     }

--- a/src/initializers/log4js/index.ts
+++ b/src/initializers/log4js/index.ts
@@ -58,6 +58,7 @@ export default async config => {
               })
               .join(', ');
             if (log) return chalk.gray(`| ${log}`);
+            return '';
           }
         }
       }

--- a/src/initializers/rabbitmq/index.ts
+++ b/src/initializers/rabbitmq/index.ts
@@ -70,7 +70,7 @@ export default (config, orkaOptions: Partial<OrkaOptions>) => {
     const store = new Map([['correlationId', this.getCorrelationId(msg)]]);
     return runWithContext(store, () => {
       appendToStore(store, msg?.properties, config);
-      originalTryHandle.call(this, retries, msg, ack);
+      return originalTryHandle.call(this, retries, msg, ack);
     });
   };
 

--- a/src/orka-builder.ts
+++ b/src/orka-builder.ts
@@ -132,7 +132,7 @@ export default class OrkaBuilder {
   }
 
   withKafka(options = this.options.kafkaProducer) {
-    this.queue.push(() => kafka(this.config.kafka, this.options.kafkaProducer));
+    this.queue.push(() => kafka(this.config, options));
     return this;
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -24,7 +24,11 @@ export const nodeVersionGreaterThanEqual = (requestedVersion: string, version = 
   return true;
 };
 
-export function appendHeadersFromStore(properties: any, store: Map<string, any>, config: any) {
+export function appendHeadersFromStore(
+  properties: { headers?: Record<string, string | Buffer | undefined> },
+  store: Map<string, string | Record<string, string>>,
+  config: Record<string, any>
+) {
   if (!config.requestContext.enabled) return;
   if (!config.requestContext.propagatedHeaders.enabled) return;
   properties.headers = properties.headers || {};
@@ -46,10 +50,14 @@ export function appendHeadersFromStore(properties: any, store: Map<string, any>,
   Object.keys(headers).forEach(key => {
     properties.headers[key] = properties.headers[key] ?? headers[key];
   });
-  properties.headers['x-depth'] = depth;
+  properties.headers['x-depth'] = depth.toString();
 }
 
-export function appendToStore(store, properties, config) {
+export function appendToStore(
+  store: Map<string, string | Record<string, string | string[]>>,
+  properties: { headers?: Record<string, string | string[]> },
+  config: Record<string, any>
+) {
   if (!config.requestContext.enabled) return;
   if (!config.requestContext.propagatedHeaders.enabled) return;
   if (!properties?.headers) return;

--- a/test/initializers/kafka/kafka.test.ts
+++ b/test/initializers/kafka/kafka.test.ts
@@ -26,7 +26,7 @@ describe('kafka class', () => {
       on: sandbox.stub(),
       events: {
         CONNECT: 'producer.connect',
-        DISCONNECT: 'producer.disconnect',
+        DISCONNECT: 'producer.disconnect'
       }
     };
     consumerStub = sandbox.stub().returns({
@@ -45,7 +45,7 @@ describe('kafka class', () => {
       createTopics: createTopicsStub,
       fetchOffsets: fetchOffsetsStub,
       setOffsets: setOffsetsStub,
-      listTopics: listTopicsStub,
+      listTopics: listTopicsStub
     });
     kafkaStubReturn = { producer: () => producerStub, consumer: consumerStub, admin: adminStub };
     kafkaStub = sinon.stub().returns(kafkaStubReturn);
@@ -59,7 +59,7 @@ describe('kafka class', () => {
     mock.stopAll();
   });
 
-  describe('connect, send', function () {
+  describe('connect', function () {
     context('with certificates', function () {
       it('should call correct methods with correct args', async () => {
         const kafka = new Kafka({
@@ -77,7 +77,6 @@ describe('kafka class', () => {
         await kafka.connect();
         producerStub.connect.calledOnce.should.eql(true);
 
-        await kafka.send('topic', 'msg', null, null, [{ header1: 'header' }, { header2: 'header' }]);
         kafkaStub.args.should.containDeep([
           [
             {
@@ -86,9 +85,6 @@ describe('kafka class', () => {
               ssl: { ca: ['ca'], cert: 'cert', key: 'key', rejectUnauthorized: false }
             }
           ]
-        ]);
-        producerStub.send.args.should.containDeep([
-          [{ messages: [{ headers: { header1: 'header', header2: 'header' }, value: 'msg' }], topic: 'topic' }]
         ]);
       });
     });
@@ -110,7 +106,6 @@ describe('kafka class', () => {
         await kafka.connect();
         producerStub.connect.calledOnce.should.eql(true);
 
-        await kafka.send('topic', 'msg', null, null);
         kafkaStub.args.should.containDeep([
           [
             {
@@ -120,7 +115,6 @@ describe('kafka class', () => {
             }
           ]
         ]);
-        producerStub.send.args.should.containDeep([[{ messages: [{ value: 'msg' }], topic: 'topic' }]]);
       });
     });
 
@@ -144,7 +138,6 @@ describe('kafka class', () => {
         await kafka.connect(producerConfig);
         producerStub.connect.calledOnce.should.eql(true);
 
-        await kafka.send('topic', 'msg', null, null, [{ header1: 'header' }, { header2: 'header' }]);
         producerSpy.args.should.eql([[producerConfig]]);
         kafkaStub.args.should.containDeep([
           [
@@ -155,9 +148,6 @@ describe('kafka class', () => {
               sasl: { mechanism: 'scram-sha-256', password: 'foo-producer', username: 'bar' }
             }
           ]
-        ]);
-        producerStub.send.args.should.containDeep([
-          [{ messages: [{ headers: { header1: 'header', header2: 'header' }, value: 'msg' }], topic: 'topic' }]
         ]);
       });
     });
@@ -350,9 +340,7 @@ describe('kafka class', () => {
         { topic: 'test', numPartitions: 10, replicationFactor: 1 }
       ]);
       adminStub.args.should.eql([[]]);
-      createTopicsStub.args.should.eql([
-        [{ topics: [{ numPartitions: 10, replicationFactor: 1, topic: 'bar' }] }],
-      ]);
+      createTopicsStub.args.should.eql([[{ topics: [{ numPartitions: 10, replicationFactor: 1, topic: 'bar' }] }]]);
       response.should.eql([{ bar: true }]);
     });
   });

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -66,30 +66,30 @@ describe('utils', function () {
       it('propagates headers from store to properties', function () {
         const properties = {};
         appendHeadersFromStore(properties, new Map([['propagatedHeaders', { foo: 'bar' }]]), Config);
-        properties.should.eql({ headers: { foo: 'bar', 'x-depth': 1 } });
+        properties.should.eql({ headers: { foo: 'bar', 'x-depth': '1' } });
       });
 
       it('propagates headers from store to properties chaning trace id', function () {
         sandbox.stub(crypto, 'randomUUID').returns('new-uuid' as any);
         const properties = {};
-        const store = new Map([['propagatedHeaders', { foo: 'bar', 'x-depth': 1 }]]);
+        const store = new Map([['propagatedHeaders', { foo: 'bar', 'x-depth': '1' }]]);
         appendHeadersFromStore(properties, store, Config);
-        properties.should.eql({ headers: { foo: 'orka:new-uuid', 'x-parent-id': 'bar', 'x-depth': 2 } });
-        Object.fromEntries(store).should.eql({ propagatedHeaders: { foo: 'bar', 'x-depth': 1 } });
+        properties.should.eql({ headers: { foo: 'orka:new-uuid', 'x-parent-id': 'bar', 'x-depth': '2' } });
+        Object.fromEntries(store).should.eql({ propagatedHeaders: { foo: 'bar', 'x-depth': '1' } });
       });
 
       it('propagates headers from store to properties adding initiator id too', function () {
         sandbox.stub(crypto, 'randomUUID').returns('new-uuid' as any);
         const properties = { headers: { 'x-parent-id': 'irrelevant' } };
 
-        const store = new Map([['propagatedHeaders', { foo: 'parent-id', 'x-depth': 3, 'x-parent-id': 'bar' }]]);
+        const store = new Map([['propagatedHeaders', { foo: 'parent-id', 'x-depth': '3', 'x-parent-id': 'bar' }]]);
 
         appendHeadersFromStore(properties, store, Config);
         properties.should.eql({
-          headers: { foo: 'orka:new-uuid', 'x-parent-id': 'parent-id', 'x-depth': 4, 'x-initiator-id': 'bar' }
+          headers: { foo: 'orka:new-uuid', 'x-parent-id': 'parent-id', 'x-depth': '4', 'x-initiator-id': 'bar' }
         });
         Object.fromEntries(store).should.eql({
-          propagatedHeaders: { foo: 'parent-id', 'x-depth': 3, 'x-parent-id': 'bar' }
+          propagatedHeaders: { foo: 'parent-id', 'x-depth': '3', 'x-parent-id': 'bar' }
         });
       });
     });


### PR DESCRIPTION


## Description
This pull request includes several updates aimed at enhancing the functionality of Kafka and RabbitMQ. The changes include the deprecation of a Kafka function, propagation of headers in Kafka messages, updates to the examples configuration, and modifications to the logTracer and rabbitmq initializer functions.

## Changes
- Deprecated `kafka send message` in favor of `kafka.producer.send`
- Enabled propagation of headers in Kafka messages
- Updated examples configuration
- Modified `logTracer` function to return an empty string instead of undefined
- Updated `rabbitmq initializer` to return `originalTryHandle` call