### PR TITLE
Add postgres statement_timeout and query_timeout

### DIFF
--- a/docs/integrations/postgres.md
+++ b/docs/integrations/postgres.md
@@ -43,6 +43,8 @@ module.exports = {
     useSsl: true,
     idleTimeoutMillis: 10000,
     connectionTimeoutMillis: 0,
+    statementTimeout: undefined, // default is no timeout
+    queryTimeout: undefined // default is no timeout
     sslConfig: {
       rejectUnauthorized: false,
       ca: '',

--- a/src/initializers/postgres.ts
+++ b/src/initializers/postgres.ts
@@ -20,7 +20,9 @@ export default function postgres(config) {
       max: pgConfig.poolSize,
       ssl: pgConfig.useSsl ? pgConfig.sslConfig : undefined,
       idleTimeoutMillis: pgConfig.idleTimeoutMillis,
-      connectionTimeoutMillis: pgConfig.connectionTimeoutMillis
+      connectionTimeoutMillis: pgConfig.connectionTimeoutMillis,
+      statement_timeout: pgConfig.statementTimeout,
+      query_timeout: pgConfig.queryTimeout,
     });
     logger.info(`Connected to Postgres! (${pgConfig.url.split('@')[1] || pgConfig.url})`);
     pool.on('error', err => {

--- a/test/initializers/postgres.test.ts
+++ b/test/initializers/postgres.test.ts
@@ -70,7 +70,9 @@ describe('Test postgres connection', function () {
           key: ''
         },
         idleTimeoutMillis: 10000,
-        connectionTimeoutMillis: 0
+        connectionTimeoutMillis: 0,
+        statementTimeout: 3000,
+        queryTimeout: 5000
       }
     });
     poolStub.args.should.eql([
@@ -80,7 +82,9 @@ describe('Test postgres connection', function () {
           max: undefined,
           ssl: undefined,
           idleTimeoutMillis: 10000,
-          connectionTimeoutMillis: 0
+          connectionTimeoutMillis: 0,
+          statement_timeout: 3000,
+          query_timeout: 5000,
         }
       ]
     ]);

--- a/test/initializers/postgres.test.ts
+++ b/test/initializers/postgres.test.ts
@@ -52,7 +52,9 @@ describe('Test postgres connection', function () {
           max: undefined,
           ssl: { rejectUnauthorized: false },
           idleTimeoutMillis: undefined,
-          connectionTimeoutMillis: undefined
+          connectionTimeoutMillis: undefined,
+          statement_timeout: undefined,
+          query_timeout: undefined,
         }
       ]
     ]);
@@ -117,7 +119,9 @@ describe('Test postgres connection', function () {
             key: 'key'
           },
           idleTimeoutMillis: 10000,
-          connectionTimeoutMillis: 0
+          connectionTimeoutMillis: 0,
+          statement_timeout: undefined,
+          query_timeout: undefined,
         }
       ]
     ]);


### PR DESCRIPTION
We want to be able to configure statement and query timeout in a postgres pool. Without adding any variable, the default will remain to no timeout.

Currently in an application that uses orka's postgres connection, this can be handled only in database level. 

Documentation: https://node-postgres.com/apis/client