### PR TITLE
[PROD-37017] Allow orka to accept s3 presigned URLs with region

### DIFF
--- a/src/initializers/joi.ts
+++ b/src/initializers/joi.ts
@@ -18,7 +18,11 @@ export const isOwnS3Path = (bucket: string, val: string): boolean => {
       host.startsWith('s3.') &&
       host.endsWith('.amazonaws.com') &&
       pathname.startsWith(`/${bucket}/`);
-    return matchingProtocol && (s3Host || s3HostBucketInPath);
+    const s3HostContainsRegion =
+			host.startsWith(`${bucket}.s3`) &&
+			host.endsWith('.amazonaws.com') &&
+			host.split('.').length === 5;
+    return matchingProtocol && (s3Host || s3HostBucketInPath || s3HostContainsRegion);
   } catch (e) {
     logger.error(`Failed to parse url: ${val}`, e);
     return false;

--- a/test/initializers/joi.test.ts
+++ b/test/initializers/joi.test.ts
@@ -1,6 +1,6 @@
 import should = require('should');
 import Joi from '../../src/initializers/joi';
-import { isExpiredUrl } from '../../src/initializers/joi';
+import { isExpiredUrl, isOwnS3Path } from '../../src/initializers/joi';
 import * as sinon from 'sinon';
 
 describe('joi extensions', function () {
@@ -257,6 +257,28 @@ describe('joi extensions', function () {
         isExpiredUrl('https://bucket.s3.amazonaws.com?X-Amz-Date=20230101T100000Z&X-Amz-Expires=604800')
       ];
       isExpired.map((x) => x.should.be.false());
+    });
+  });
+
+  describe('isOwnS3Path', function () {
+    it('should return true for valid s3 path', function () {
+      const isOwnPath = [
+        isOwnS3Path('some-bucket', 'https://s3.amazonaws.com/some-bucket/some-file-name'),
+        isOwnS3Path('some-bucket', 'https://some-bucket.s3.some-region-1.amazonaws.com/'),
+        isOwnS3Path('some-bucket', 'https://some-bucket.s3.amazonaws.com/'),
+      ];
+      isOwnPath.map((x) => x.should.be.true());
+    });
+
+    it('should return false for invalid s3 path', function () {
+      const isOwnPath = [
+        isOwnS3Path('some-bucket', 'https://s3.amazonaws.com/some-other-bucket/some-file-name'),
+        isOwnS3Path('some-bucket', 'https://some-other-bucket.s3.some-region-1.amazonaws.com/'),
+        isOwnS3Path('some-bucket', 'https://some-other-bucket.s3.amazonaws.com/'),
+        isOwnS3Path('some-bucket', 'https://some-other-bucket.s3.some.deep.nested.subdomain.amazonaws.com/'),
+        isOwnS3Path('some-bucket', 'https://some-bucket.s3.some.deep.nested.subdomain.amazonaws.com/')
+      ];
+      isOwnPath.map((x) => x.should.be.false());
     });
   });
 });


### PR DESCRIPTION
- Expands the `isOwnS3Path` function to accept presigned URLs that contain region in the hostname.