### PR TITLE
[PROD-40813] Allow safeHtml to support no-html rule

### DIFF
--- a/src/initializers/joi.ts
+++ b/src/initializers/joi.ts
@@ -260,7 +260,6 @@ const Joi: JoiWithExtensions = _Joi.extend(
         args: [
           {
             name: 'allowedTags',
-            assert: value => Array.isArray(value) && value.length > 0,
             message: 'must be a non empty array'
           }
         ],
@@ -275,7 +274,6 @@ const Joi: JoiWithExtensions = _Joi.extend(
         args: [
           {
             name: 'allowedAttributes',
-            assert: value => typeof value === 'object' && Object.keys(value).length > 0,
             message: 'must be a non empty object'
           }
         ],

--- a/test/initializers/joi.test.ts
+++ b/test/initializers/joi.test.ts
@@ -222,6 +222,10 @@ describe('joi extensions', function () {
         .should
         .equal('<a href="http://google.com" class="aclass"></a>foo');
     });
+    it('no html at all', function () {
+      Joi.safeHtml().allowedAttributes({}).allowedTags([])
+        .validate('<p>banana</p>').value.should.equal('banana');
+    });
   });
 
   describe('objectid', function () {


### PR DESCRIPTION
## Summary
Allows users to define rules like 
```js
Joi.safeHtml().allowedTags([]).allowedAttributes({})
```
which instructs joi to strip all HTML values