### PR TITLE
Migrate KafkaJS to ^2.0.0

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -75,8 +75,4 @@ ObjectId using new mongoose.
 - Changes in default config: istioTraceHeaders and headerPropagation are deprecated in favor of a generic propagatedHeaders
 - Methods kafka.send that was deprecated is removed. Use kafka.producer.send instead
 - Mongoose migrated to v7 which has breaking changes see [here](https://mongoosejs.com/docs/7.x/docs/migrating_to_7.html)
-
-### Migrating from orka  4.x to 5.x
-- KafkaJS version is specified to 2.x.x. KafkaJS 2.x.x will use the JavaCompatiblePartitioner as the DefaultPartitioner
-- Additional information about breaking changes when migrating to KafkaJS 2.x.x can be found at https://kafka.js.org/docs/migration-guide-v2.0.0#producer-new-default-partitioner
-- If needed, you can specify the old Default Partitioner by passing it as an option when instantiating Orka (more info [here](https://workable.github.io/orka/integrations/kafka.html#migrating-from-orka--5xx))
+- KafkaJS version is specified to 2.x.x. Additional information about breaking changes when migrating to KafkaJS 2.x.x can be found at https://kafka.js.org/docs/migration-guide-v2.0.0

--- a/docs/index.md
+++ b/docs/index.md
@@ -75,3 +75,8 @@ ObjectId using new mongoose.
 - Changes in default config: istioTraceHeaders and headerPropagation are deprecated in favor of a generic propagatedHeaders
 - Methods kafka.send that was deprecated is removed. Use kafka.producer.send instead
 - Mongoose migrated to v7 which has breaking changes see [here](https://mongoosejs.com/docs/7.x/docs/migrating_to_7.html)
+
+### Migrating from orka  4.x to 5.x
+- KafkaJS version is specified to 2.x.x. KafkaJS 2.x.x will use the JavaCompatiblePartitioner as the DefaultPartitioner
+- Additional information about breaking changes when migrating to KafkaJS 2.x.x can be found at https://kafka.js.org/docs/migration-guide-v2.0.0#producer-new-default-partitioner
+- If needed, you can specify the old Default Partitioner by passing it as an option when instantiating Orka (more info [here](https://workable.github.io/orka/integrations/kafka.html#migrating-from-orka--5xx))

--- a/docs/integrations/kafka.md
+++ b/docs/integrations/kafka.md
@@ -242,3 +242,24 @@ You also need to specify the new group ids in your consumers while previously yo
 Once the new group ids are created you can remove the code that copies their offsets from old group ids. This is causing no issues thought as it doesn't do anything if the new group ids are found with offsets set.
 
 If you are using the renameGroupIds (before creating your consumers) your consumers will continue reading messages from the offset specified from the old groupId regardless if you set the fromBeginning configuration. FromBeginning configuration will be used if the groupId, topic is not found in kafka.
+
+## Migrating from orka < 5.x.x
+
+Since Orka 5.x.x, the required KafkaJS version is ^2.x.x
+(more info on the KafkaJS changes [here](https://kafka.js.org/docs/migration-guide-v2.0.0))
+
+The only possible implication is the update of the DefaultPartitioner (https://kafka.js.org/docs/migration-guide-v2.0.0#producer-new-default-partitioner). This may case
+issues in partition-aware environments, since some messages may be produced in different partitions than they would with the previous default partitioner.
+
+By default, Orka ^5.x.x will use the new DefaultPartitioner (previously named JavaCompatiblePartitioner).
+You can use the previous DefaultPartitioner (now renamed to LegacyPartitioner) with:
+
+```js
+import { Partitioners } from 'kafkajs';
+
+builder({…some static options here…})
+  ...
+  .withKafka({ createPartitioner: Partitioners.LegacyPartitioner })
+  .start(8080);
+```
+

--- a/docs/integrations/kafka.md
+++ b/docs/integrations/kafka.md
@@ -243,7 +243,7 @@ Once the new group ids are created you can remove the code that copies their off
 
 If you are using the renameGroupIds (before creating your consumers) your consumers will continue reading messages from the offset specified from the old groupId regardless if you set the fromBeginning configuration. FromBeginning configuration will be used if the groupId, topic is not found in kafka.
 
-## Migrating from orka < 5.x.x
+## Migrating from orka < 4.x.x
 
 Since Orka 5.x.x, the required KafkaJS version is ^2.x.x
 (more info on the KafkaJS changes [here](https://kafka.js.org/docs/migration-guide-v2.0.0))
@@ -251,7 +251,7 @@ Since Orka 5.x.x, the required KafkaJS version is ^2.x.x
 The only possible implication is the update of the DefaultPartitioner (https://kafka.js.org/docs/migration-guide-v2.0.0#producer-new-default-partitioner). This may case
 issues in partition-aware environments, since some messages may be produced in different partitions than they would with the previous default partitioner.
 
-By default, Orka ^5.x.x will use the new DefaultPartitioner (previously named JavaCompatiblePartitioner).
+By default, Orka ^4.x.x will use the new DefaultPartitioner (previously named JavaCompatiblePartitioner).
 You can use the previous DefaultPartitioner (now renamed to LegacyPartitioner) with:
 
 ```js

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "dd-trace": "*",
         "growthbook": "npm:@growthbook/growthbook@*",
         "husky": "^3.0.9",
-        "kafkajs": "*",
+        "kafkajs": "^2.0.0",
         "lint-staged": "^9.4.3",
         "mocha": "^9.2.2",
         "mock-require": "^3.0.3",
@@ -4354,12 +4354,12 @@
       }
     },
     "node_modules/kafkajs": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/kafkajs/-/kafkajs-1.15.0.tgz",
-      "integrity": "sha512-yjPyEnQCkPxAuQLIJnY5dI+xnmmgXmhuOQ1GVxClG5KTOV/rJcW1qA3UfvyEJKTp/RTSqQnUR3HJsKFvHyTpNg==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/kafkajs/-/kafkajs-2.2.4.tgz",
+      "integrity": "sha512-j/YeapB1vfPT2iOIUn/vxdyKEuhuY2PxMBvf5JWux6iSaukAccrMtXEY/Lb7OvavDhOWME589bpLrEdnVHjfjA==",
       "dev": true,
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/kareem": {
@@ -11991,9 +11991,9 @@
       }
     },
     "kafkajs": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/kafkajs/-/kafkajs-1.15.0.tgz",
-      "integrity": "sha512-yjPyEnQCkPxAuQLIJnY5dI+xnmmgXmhuOQ1GVxClG5KTOV/rJcW1qA3UfvyEJKTp/RTSqQnUR3HJsKFvHyTpNg==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/kafkajs/-/kafkajs-2.2.4.tgz",
+      "integrity": "sha512-j/YeapB1vfPT2iOIUn/vxdyKEuhuY2PxMBvf5JWux6iSaukAccrMtXEY/Lb7OvavDhOWME589bpLrEdnVHjfjA==",
       "dev": true
     },
     "kareem": {

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "dd-trace": "*",
     "growthbook": "npm:@growthbook/growthbook@*",
     "husky": "^3.0.9",
-    "kafkajs": "*",
+    "kafkajs": "^2.0.0",
     "lint-staged": "^9.4.3",
     "mocha": "^9.2.2",
     "mock-require": "^3.0.3",
@@ -120,7 +120,7 @@
     "newrelic": "*",
     "prom-client": "*",
     "pg": "*",
-    "kafkajs": "*",
+    "kafkajs": "^2.0.0",
     "axios": "*",
     "growthbook": "*"
   }

--- a/src/initializers/kafka/index.ts
+++ b/src/initializers/kafka/index.ts
@@ -39,7 +39,7 @@ function updateSend(kafka: Kafka, config: { traceHeaderName: string }) {
       const traceHeaderName = config.traceHeaderName.toLowerCase();
       appendHeadersFromStore(message, getRequestContext(), config);
       if (!message.key && message.headers[traceHeaderName]) {
-        message.key = message.headers[traceHeaderName];
+        message.key = message.headers[traceHeaderName] as Buffer | string | null;
       }
     });
     const sent: KafkajsType.RecordMetadata[] = await originalSend.call(this, record);

--- a/src/initializers/kafka/kafka.ts
+++ b/src/initializers/kafka/kafka.ts
@@ -3,8 +3,7 @@ import requireInjected from '../../require-injected';
 import { KafkaConfig } from '../../typings/kafka';
 import type * as KafkajsType from 'kafkajs';
 import { flatten, isEmpty } from 'lodash';
-
-const { Kafka }: typeof KafkajsType = requireInjected('kafkajs');
+const { Kafka, Partitioners }: typeof KafkajsType = requireInjected('kafkajs');
 const logger = getLogger('orka.kafka');
 
 export default class OrkaKafka {
@@ -35,6 +34,7 @@ export default class OrkaKafka {
       authenticationTimeout
     });
 
+    if (options && !options.createPartitioner) options.createPartitioner = Partitioners.DefaultPartitioner;
     this.producer = this.produceClient.producer(options);
 
     const { CONNECT, DISCONNECT } = this.producer.events;
@@ -109,11 +109,11 @@ export default class OrkaKafka {
     const renamings = await Promise.all(
       groupIds
         .map(async ({ groupId, topic, oldGroupId }) => {
-          const offsets = await admin.fetchOffsets({ groupId, topic, resolveOffsets: false });
-          if (offsets.every(({ offset }) => offset === '-1')) {
+          const offsets = (await admin.fetchOffsets({ groupId, topics: [topic], resolveOffsets: false }))[0];
+          if (offsets.partitions.every(({ offset }) => offset === '-1')) {
             // groupId is not configured
-            const oldOffsets = await admin.fetchOffsets({ groupId: oldGroupId, topic, resolveOffsets: false });
-            const knownOffsets = oldOffsets?.filter(o => o.offset !== '-1');
+            const oldOffsets = (await admin.fetchOffsets({ groupId: oldGroupId, topics: [topic], resolveOffsets: false }))[0];
+            const knownOffsets = oldOffsets.partitions.filter(o => o.offset !== '-1');
             if (!isEmpty(knownOffsets)) await admin.setOffsets({ groupId, topic, partitions: knownOffsets });
             return { groupId, renamedFrom: oldGroupId, topic, oldOffsets: knownOffsets };
           } else {
@@ -179,7 +179,6 @@ function getAuthOptions(options: {
 }) {
   const { key, cert, ca } = options.certificates || {};
   if (key && cert && ca) return { ssl: { ...options.certificates, ca: flatten([ca]) } };
-
   const { username, password } = options.sasl || {};
-  if (username && password) return { sasl: options.sasl, ssl: options.ssl };
+  if (username && password) return { sasl: {...options.sasl }, ssl: options.ssl };
 }

--- a/src/initializers/kafka/kafka.ts
+++ b/src/initializers/kafka/kafka.ts
@@ -109,10 +109,10 @@ export default class OrkaKafka {
     const renamings = await Promise.all(
       groupIds
         .map(async ({ groupId, topic, oldGroupId }) => {
-          const offsets = (await admin.fetchOffsets({ groupId, topics: [topic], resolveOffsets: false }))[0];
+          const [offsets] = await admin.fetchOffsets({ groupId, topics: [topic], resolveOffsets: false });
           if (offsets.partitions.every(({ offset }) => offset === '-1')) {
             // groupId is not configured
-            const oldOffsets = (await admin.fetchOffsets({ groupId: oldGroupId, topics: [topic], resolveOffsets: false }))[0];
+            const [oldOffsets] = (await admin.fetchOffsets({ groupId: oldGroupId, topics: [topic], resolveOffsets: false }));
             const knownOffsets = oldOffsets.partitions.filter(o => o.offset !== '-1');
             if (!isEmpty(knownOffsets)) await admin.setOffsets({ groupId, topic, partitions: knownOffsets });
             return { groupId, renamedFrom: oldGroupId, topic, oldOffsets: knownOffsets };
@@ -180,5 +180,5 @@ function getAuthOptions(options: {
   const { key, cert, ca } = options.certificates || {};
   if (key && cert && ca) return { ssl: { ...options.certificates, ca: flatten([ca]) } };
   const { username, password } = options.sasl || {};
-  if (username && password) return { sasl: {...options.sasl }, ssl: options.ssl };
+  if (username && password) return { sasl: options.sasl, ssl: options.ssl };
 }

--- a/src/typings/kafka.d.ts
+++ b/src/typings/kafka.d.ts
@@ -6,7 +6,15 @@ export interface KafkaConfig {
     rejectUnauthorized: boolean;
   };
   sasl?: {
-    mechanism: 'plain' | 'scram-sha-256' | 'scram-sha-512';
+    mechanism: 'plain';
+    username: string;
+    password: string;
+  } | {
+    mechanism: 'scram-sha-256';
+    username: string;
+    password: string;
+  } | {
+    mechanism: 'scram-sha-512';
     username: string;
     password: string;
   };
@@ -24,7 +32,15 @@ export interface KafkaConfig {
     };
     ssl?: boolean;
     sasl?: {
-      mechanism: 'plain' | 'scram-sha-256' | 'scram-sha-512';
+      mechanism: 'plain';
+      username: string;
+      password: string;
+    } | {
+      mechanism: 'scram-sha-256';
+      username: string;
+      password: string;
+    } | {
+      mechanism: 'scram-sha-512';
       username: string;
       password: string;
     };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,7 +25,7 @@ export const nodeVersionGreaterThanEqual = (requestedVersion: string, version = 
 };
 
 export function appendHeadersFromStore(
-  properties: { headers?: { [key: string]: Buffer | string | (Buffer | string)[] | undefined } },
+  properties: { headers?: Record<string, string | Buffer | (Buffer | string)[] | undefined> },
   store: Map<string, string | Record<string, string>>,
   config: Record<string, any>
 ) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,7 +25,7 @@ export const nodeVersionGreaterThanEqual = (requestedVersion: string, version = 
 };
 
 export function appendHeadersFromStore(
-  properties: { headers?: Record<string, string | Buffer | undefined> },
+  properties: { headers?: { [key: string]: Buffer | string | (Buffer | string)[] | undefined } },
   store: Map<string, string | Record<string, string>>,
   config: Record<string, any>
 ) {


### PR DESCRIPTION
Bumps KafkaJS to 2.0.0

It contains two major changes that affect us

## Manage topics through admin client
KafkaJS contains some non-backwards compatible options in regards to [managing topics via the admin client](https://kafka.js.org/docs/migration-guide-v2.0.0#admin-fetchoffsets-accepts-topics-instead-of-topic)
We have changed the [implementation](https://github.com/Workable/orka/pull/384/files#diff-7a49104279a769359638eac7921420c155eb1946ead52cca31d7ecc2bf589671R112-R113) to support the new array handling of topic and offsets  

## Default partitioner
Another change is the update of the [DefaultPartitioner](https://kafka.js.org/docs/migration-guide-v2.0.0#producer-new-default-partitioner)
By default the JavaCompatiblePartitioner is used but if not explicitly set it will log a warning
We are setting it by default (if not already set) [here](https://github.com/Workable/orka/pull/384/files#diff-7a49104279a769359638eac7921420c155eb1946ead52cca31d7ecc2bf589671R37)
If for some reason someone needs to use the old partitioner (LegacyPartitioner), it can be set through the `.withKafkaOptions()`
e.g `.withKafka({ createPartitioner: Partitioners.LegacyPartitioner })`