### PR TITLE
Pass host field name to riviere to be able to use custom host

### DIFF
--- a/__snapshots__/diamorphosis.test.ts.js
+++ b/__snapshots__/diamorphosis.test.ts.js
@@ -100,7 +100,8 @@ exports['Diamorphosis Test should set json/console loggingvariables when nothing
     },
     "color": true,
     "styles": [],
-    "headersRegex": "(^X-.*)|cf-ray"
+    "headersRegex": "(^X-.*)|cf-ray",
+    "hostFieldName": "host"
   },
   "healthCheck": {
     "kafka": false,
@@ -326,7 +327,8 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
     "styles": [
       "json"
     ],
-    "headersRegex": "(^X-.*)|cf-ray"
+    "headersRegex": "(^X-.*)|cf-ray",
+    "hostFieldName": "host"
   },
   "healthCheck": {
     "kafka": false,
@@ -552,7 +554,8 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
     "styles": [
       "json"
     ],
-    "headersRegex": "(^X-.*)|cf-ray"
+    "headersRegex": "(^X-.*)|cf-ray",
+    "hostFieldName": "host"
   },
   "healthCheck": {
     "kafka": false,
@@ -778,7 +781,8 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
     "styles": [
       "json"
     ],
-    "headersRegex": "(^X-.*)|cf-ray"
+    "headersRegex": "(^X-.*)|cf-ray",
+    "hostFieldName": "host"
   },
   "healthCheck": {
     "kafka": false,
@@ -931,7 +935,8 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
     "styles": [
       "simple"
     ],
-    "headersRegex": "(^X-.*)|cf-ray"
+    "headersRegex": "(^X-.*)|cf-ray",
+    "hostFieldName": "host"
   },
   "nodeEnv": "development",
   "app": {
@@ -1283,7 +1288,8 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
     },
     "color": true,
     "styles": [],
-    "headersRegex": "(^X-.*)|cf-ray"
+    "headersRegex": "(^X-.*)|cf-ray",
+    "hostFieldName": "host"
   },
   "queue": {
     "url": "",
@@ -1516,7 +1522,8 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
     "styles": [
       "json"
     ],
-    "headersRegex": "(^X-.*)|cf-ray"
+    "headersRegex": "(^X-.*)|cf-ray",
+    "hostFieldName": "host"
   },
   "queue": {
     "url": "",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@google-cloud/debug-agent": "^5.2.8",
         "@honeybadger-io/js": "^6.5.3",
-        "@workablehr/riviere": "*",
+        "@workablehr/riviere": "1.18.0",
         "chalk": "^2.4.2",
         "codependency": "^2.1.0",
         "diamorphosis": "^1.0.0",
@@ -1147,9 +1147,9 @@
       "dev": true
     },
     "node_modules/@workablehr/riviere": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/@workablehr/riviere/-/riviere-1.16.1.tgz",
-      "integrity": "sha512-0C9W3i/onOnVE1Q8hRu57HguMA2rN76ZiYWb9MayrtpRpMkCUcbfJgq8ioFg8zYjDMhxoe7akydXot/VBDE0GQ==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@workablehr/riviere/-/riviere-1.18.0.tgz",
+      "integrity": "sha512-/Y/l1GYUAaaBaAuKvLoD8VGYGrfjt6SSNLhz7ZI2s2dvcefLV2Yxj4Phwslizeyg37bKGZV2W+SrTItUqVBA8A==",
       "dependencies": {
         "chalk": "^2.4.2",
         "flat": "^5.0.2",
@@ -9547,9 +9547,9 @@
       "dev": true
     },
     "@workablehr/riviere": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/@workablehr/riviere/-/riviere-1.16.1.tgz",
-      "integrity": "sha512-0C9W3i/onOnVE1Q8hRu57HguMA2rN76ZiYWb9MayrtpRpMkCUcbfJgq8ioFg8zYjDMhxoe7akydXot/VBDE0GQ==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@workablehr/riviere/-/riviere-1.18.0.tgz",
+      "integrity": "sha512-/Y/l1GYUAaaBaAuKvLoD8VGYGrfjt6SSNLhz7ZI2s2dvcefLV2Yxj4Phwslizeyg37bKGZV2W+SrTItUqVBA8A==",
       "requires": {
         "chalk": "^2.4.2",
         "flat": "^5.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@google-cloud/debug-agent": "^5.2.8",
         "@honeybadger-io/js": "^6.5.3",
-        "@workablehr/riviere": "1.18.0",
+        "@workablehr/riviere": "*",
         "chalk": "^2.4.2",
         "codependency": "^2.1.0",
         "diamorphosis": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "dependencies": {
     "@google-cloud/debug-agent": "^5.2.8",
     "@honeybadger-io/js": "^6.5.3",
-    "@workablehr/riviere": "github:Workable/riviere#host",
+    "@workablehr/riviere": "*",
     "chalk": "^2.4.2",
     "codependency": "^2.1.0",
     "diamorphosis": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "dependencies": {
     "@google-cloud/debug-agent": "^5.2.8",
     "@honeybadger-io/js": "^6.5.3",
-    "@workablehr/riviere": "*",
+    "@workablehr/riviere": "github:Workable/riviere#host",
     "chalk": "^2.4.2",
     "codependency": "^2.1.0",
     "diamorphosis": "^1.0.0",

--- a/src/initializers/diamorphosis.ts
+++ b/src/initializers/diamorphosis.ts
@@ -93,6 +93,7 @@ export default (config, orkaOptions: Partial<OrkaOptions>) => {
     styles: [],
     headersRegex: '(^X-.*)|cf-ray',
     maxBodyValueChars: undefined,
+    hostFieldName: 'host',
     ...config.riviere
   };
 

--- a/src/initializers/riviere.ts
+++ b/src/initializers/riviere.ts
@@ -48,6 +48,7 @@ const init = (config, orkaOptions) => {
     bodyKeysRegex: config.riviere.bodyKeysRegex && new RegExp(config.riviere.bodyKeysRegex, 'i'),
     bodyKeysCallback: config.riviere.bodyKeysCallback,
     color: config.riviere.color,
+    hostFieldName: config.riviere.hostFieldName,
     context: (ctx: Koa.Context) => {
       return {
         visitor: ctx.state.visitor,


### PR DESCRIPTION
After making host field name configurable in riviere `1.18.0` we should initialize it via orka in order to support custom host on all node applications.

https://workable.atlassian.net/browse/PROD-43442