### PR TITLE
PROD-54189 Convert Riviere's config blackistedPathRegex to RegExp when passing it

### DIFF
--- a/src/initializers/riviere.ts
+++ b/src/initializers/riviere.ts
@@ -24,11 +24,11 @@ const init = (config, orkaOptions) => {
       https: true,
       level: 'info',
       maxBodyValueChars: config.riviere.maxBodyValueChars,
-      blacklistedPathRegex: config.riviere.outbound && config.riviere.outbound.blacklistedPathRegex,
       request: {
         enabled: config.riviere.outbound && config.riviere.outbound.request.enabled
       },
-      ...config.riviere.outbound
+      ...config.riviere.outbound,
+      blacklistedPathRegex: config.riviere.outbound && new RegExp(config.riviere.outbound.blacklistedPathRegex, 'i')
     },
     inbound: {
       level: 'info',


### PR DESCRIPTION
Converted from https://github.com/Workable/riviere/pull/113

We discovered that when `blacklistedPathRegex` was set via env var it would be passed as string to Riviere instead of a RegExp object which caused requests to not get logged.