### PR TITLE
Update regex handling to respect flags from config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@workablehr/riviere": "*",
         "chalk": "^2.4.2",
         "codependency": "^2.1.0",
-        "diamorphosis": "^1.0.0",
+        "diamorphosis": "^1.1.0",
         "fast-koa-router": "^1.3.0",
         "joi": "^17.5.0",
         "koa": "^2.14.2",
@@ -2618,9 +2618,9 @@
       }
     },
     "node_modules/diamorphosis": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/diamorphosis/-/diamorphosis-1.0.0.tgz",
-      "integrity": "sha512-n44u9rwmxYJZPekremjfJAv2Ec9O6Qyyfxccenbr/EtTBaDUNF22c9yfJganssQbTAxTuyPf4Qn9A4EAT7xwQA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/diamorphosis/-/diamorphosis-1.1.0.tgz",
+      "integrity": "sha512-rVp7qZFRR2x6Qt5YhRpah9cqhyw7N2TfZk6EcbYGE1qdntqPDsvxjdIZ80+fXLrxCcsPVRj3vXuN8jmyD9oKSA==",
       "dependencies": {
         "deep-extend": "^0.6.0",
         "dotenv": "^2.0.0"
@@ -11393,9 +11393,9 @@
       "dev": true
     },
     "diamorphosis": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/diamorphosis/-/diamorphosis-1.0.0.tgz",
-      "integrity": "sha512-n44u9rwmxYJZPekremjfJAv2Ec9O6Qyyfxccenbr/EtTBaDUNF22c9yfJganssQbTAxTuyPf4Qn9A4EAT7xwQA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/diamorphosis/-/diamorphosis-1.1.0.tgz",
+      "integrity": "sha512-rVp7qZFRR2x6Qt5YhRpah9cqhyw7N2TfZk6EcbYGE1qdntqPDsvxjdIZ80+fXLrxCcsPVRj3vXuN8jmyD9oKSA==",
       "requires": {
         "deep-extend": "^0.6.0",
         "dotenv": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@workablehr/riviere": "*",
     "chalk": "^2.4.2",
     "codependency": "^2.1.0",
-    "diamorphosis": "^1.0.0",
+    "diamorphosis": "^1.1.0",
     "fast-koa-router": "^1.3.0",
     "joi": "^17.5.0",
     "koa": "^2.14.2",

--- a/src/initializers/riviere.ts
+++ b/src/initializers/riviere.ts
@@ -28,7 +28,7 @@ const init = (config, orkaOptions) => {
         enabled: config.riviere.outbound && config.riviere.outbound.request.enabled
       },
       ...config.riviere.outbound,
-      blacklistedPathRegex: config.riviere.outbound && new RegExp(config.riviere.outbound.blacklistedPathRegex, 'i')
+      blacklistedPathRegex: config.riviere.outbound && RegExp(config.riviere.outbound.blacklistedPathRegex)
     },
     inbound: {
       level: 'info',
@@ -42,11 +42,11 @@ const init = (config, orkaOptions) => {
     errors: {
       enabled: config.riviere.enabled
     } as any,
-    headersRegex: new RegExp(config.riviere.headersRegex, 'i'),
+    headersRegex: RegExp(config.riviere.headersRegex),
     traceHeaderName: config.traceHeaderName,
     styles: config.riviere.styles,
     bodyKeys: config.riviere.bodyKeys,
-    bodyKeysRegex: config.riviere.bodyKeysRegex && new RegExp(config.riviere.bodyKeysRegex, 'i'),
+    bodyKeysRegex: config.riviere.bodyKeysRegex && RegExp(config.riviere.bodyKeysRegex),
     bodyKeysCallback: config.riviere.bodyKeysCallback,
     color: config.riviere.color,
     hostFieldName: config.riviere.hostFieldName,

--- a/test/initializers/riviere.test.ts
+++ b/test/initializers/riviere.test.ts
@@ -1,0 +1,47 @@
+import * as riviere from '@workablehr/riviere';
+import * as sinon from 'sinon';
+import orkaRiviereInitializer from '../../src/initializers/riviere';
+
+const sandbox = sinon.createSandbox();
+
+describe('riviere', () => {
+  let orkaOptions;
+  let riviereStub;
+
+  beforeEach(() => {
+    orkaOptions = {
+      riviereContext: () => ({})
+    };
+
+    riviereStub = sandbox.stub(riviere, 'riviere').returns({});
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('should respect regex flags from config', () => {
+    const config = {
+      riviere: {
+        enabled: true,
+        outbound: {
+          enabled: true,
+          blacklistedPathRegex: /some-regex/gim,
+          request: {
+            enabled: true
+          }
+        },
+        headersRegex: /some-regex/gi,
+        inbound: {
+          request: {
+            enabled: true
+          }
+        }
+      }
+    };
+
+    orkaRiviereInitializer(config, orkaOptions);
+    riviereStub.args[0][0].headersRegex.should.eql(/some-regex/gi);
+    riviereStub.args[0][0].outbound.blacklistedPathRegex.should.eql(/some-regex/gim);
+  });
+});


### PR DESCRIPTION
Currently when Orka is passing a regex (to riviere), it overwrites any flags that were set in the app config. This PR changes that so it will respect flags that were set in config when overriding a value from config/env values.