### PR TITLE
Chore version to 4.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@workablehr/orka",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@workablehr/orka",
-      "version": "4.2.1",
+      "version": "4.2.2",
       "license": "ISC",
       "dependencies": {
         "@google-cloud/debug-agent": "^5.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workablehr/orka",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "",
   "main": "build/index.js",
   "scripts": {


### PR DESCRIPTION
Change version in order to get koa > 2.14.5 and fix the vulnerability issues at services, like [campaign](https://github.com/Workable/campaigns/security/dependabot/133) 