### PR TITLE
Add original Axios response to AxiosError of orka

### DIFF
--- a/__snapshots__/axios-error-interceptor.test.ts.js
+++ b/__snapshots__/axios-error-interceptor.test.ts.js
@@ -10,5 +10,11 @@ exports['axios error interceptor should add context in error object for failed g
       "data": ""
     },
     "method": "get"
+  },
+  "response": {
+    "status": 404,
+    "statusText": null,
+    "headers": {},
+    "data": ""
   }
 }

--- a/__snapshots__/axios-errors.test.ts.js
+++ b/__snapshots__/axios-errors.test.ts.js
@@ -7,5 +7,9 @@ exports['axios error AxiosError 1'] = {
       "statusText": "internal server error"
     },
     "method": "GET"
+  },
+  "response": {
+    "status": 500,
+    "statusText": "internal server error"
   }
 }

--- a/src/errors/axios-error.ts
+++ b/src/errors/axios-error.ts
@@ -7,6 +7,7 @@ export class AxiosError extends CustomError {
   public context: object;
   public status: number;
   public code?: string;
+  public response?: Omit<axios.AxiosResponse, 'request' | 'config'>;
 
   constructor(err: axios.AxiosError) {
     if (err.response) {
@@ -29,6 +30,7 @@ export class AxiosError extends CustomError {
       requestData: err.response?.config?.data,
       method: err.config?.method
     };
+    this.response = err.response ? omit(err.response, ['request', 'config']) : undefined;
   }
 
   public [util.inspect.custom]() {


### PR DESCRIPTION
The issue:
Axios Interceptor changes the original type of the AxiosError. As a result packages that depend on axios and happen to be on the same version get a modified version of Error. Most of this packages like [helloSign](https://github.com/hellosign/dropbox-sign-node/blob/main/api/signatureRequestApi.ts#L245) depend on the response to handle the error. With this pr this is feasible.