### PR TITLE
[PROD-70400] Add qs default config to allow us bump the module

### DIFF
--- a/__snapshots__/diamorphosis.test.ts.js
+++ b/__snapshots__/diamorphosis.test.ts.js
@@ -111,6 +111,11 @@ exports['Diamorphosis Test should set json/console loggingvariables when nothing
     "cookie": "",
     "setCookie": false
   },
+  "queryParser": {
+    "arrayLimit": 1000,
+    "parameterLimit": 1000,
+    "depth": 5
+  },
   "kafka": {
     "brokers": [],
     "groupId": "",
@@ -337,6 +342,11 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
   "visitor": {
     "cookie": "",
     "setCookie": false
+  },
+  "queryParser": {
+    "arrayLimit": 1000,
+    "parameterLimit": 1000,
+    "depth": 5
   },
   "kafka": {
     "brokers": [],
@@ -565,6 +575,11 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
     "cookie": "",
     "setCookie": false
   },
+  "queryParser": {
+    "arrayLimit": 1000,
+    "parameterLimit": 1000,
+    "depth": 5
+  },
   "kafka": {
     "brokers": [],
     "groupId": "",
@@ -791,6 +806,11 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
   "visitor": {
     "cookie": "",
     "setCookie": false
+  },
+  "queryParser": {
+    "arrayLimit": 1000,
+    "parameterLimit": 1000,
+    "depth": 5
   },
   "kafka": {
     "brokers": [],
@@ -1019,6 +1039,11 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
     "cookie": "",
     "setCookie": false
   },
+  "queryParser": {
+    "arrayLimit": 1000,
+    "parameterLimit": 1000,
+    "depth": 5
+  },
   "kafka": {
     "brokers": [],
     "groupId": "",
@@ -1187,6 +1212,11 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
   "visitor": {
     "cookie": "cookie",
     "setCookie": false
+  },
+  "queryParser": {
+    "arrayLimit": 1000,
+    "parameterLimit": 1000,
+    "depth": 5
   },
   "app": {
     "env": "testProcess"
@@ -1419,6 +1449,11 @@ exports['Diamorphosis Test should set json/console loggingvariables when console
   "visitor": {
     "cookie": "cookie",
     "setCookie": false
+  },
+  "queryParser": {
+    "arrayLimit": 1000,
+    "parameterLimit": 1000,
+    "depth": 5
   },
   "app": {
     "env": "testProcess"

--- a/src/initializers/diamorphosis.ts
+++ b/src/initializers/diamorphosis.ts
@@ -114,6 +114,7 @@ export default (config, orkaOptions: Partial<OrkaOptions>) => {
   addMongoDBConfig(config);
   addRedisConfig(config);
   addPostgresConfig(config);
+  addQueryParserConfig(config);
   addWorkersConfig(config);
   addGrowthbookConfig(config);
 
@@ -267,6 +268,15 @@ function addRedisConfig(config) {
         ...config?.redis?.options?.tls
       }
     }
+  };
+}
+
+function addQueryParserConfig(config) {
+  config.queryParser = {
+    arrayLimit: 1000,
+    parameterLimit: 1000,
+    depth: 5,
+    ...config.queryParser
   };
 }
 

--- a/src/initializers/koa/parse-querystring.ts
+++ b/src/initializers/koa/parse-querystring.ts
@@ -1,17 +1,30 @@
-import { Context, Next } from 'koa';
+import { Context, Next, Middleware } from 'koa';
 import * as qs from 'qs';
 
-export default async function parseQuerystring(ctx: Context, next: Next) {
-  if (ctx.querystring) {
-    let query;
-    Object.defineProperty(ctx.state, 'query', {
-      get() {
-        return query || qs.parse(ctx.querystring);
-      },
-      set(v) {
-        query = v;
-      }
-    });
-  }
-  return next();
+const defaultQueryParserOptions = {
+  arrayLimit: 1000,
+  parameterLimit: 1000,
+  depth: 5
+};
+
+export default function parseQuerystring(config: { queryParser?: qs.IParseOptions } = {}): Middleware {
+  const options: qs.IParseOptions = {
+    ...defaultQueryParserOptions,
+    ...config.queryParser
+  };
+
+  return async function parseQuerystringMiddleware(ctx: Context, next: Next) {
+    if (ctx.querystring) {
+      let query;
+      Object.defineProperty(ctx.state, 'query', {
+        get() {
+          return query || qs.parse(ctx.querystring, options);
+        },
+        set(v) {
+          query = v;
+        }
+      });
+    }
+    return next();
+  };
 }

--- a/src/orka-builder.ts
+++ b/src/orka-builder.ts
@@ -73,7 +73,7 @@ export default class OrkaBuilder {
       this.use(() => addRequestContext(this.als, this.config));
     }
     this.use(() => bodyParser(this.config.bodyParser));
-    this.use(() => parseQuerystring);
+    this.use(() => parseQuerystring(this.config));
     this.use(() => riviere(this.config, this.options));
     this.use(() => this.errorHandler(this.config, this.options));
     this.use(

--- a/test/initializers/koa/parse-querystring.test.ts
+++ b/test/initializers/koa/parse-querystring.test.ts
@@ -1,7 +1,15 @@
 import * as sinon from 'sinon';
-import middleware from '../../../src/initializers/koa/parse-querystring';
+import parseQuerystring from '../../../src/initializers/koa/parse-querystring';
 
 const sandbox = sinon.createSandbox();
+
+const defaultConfig = {
+  queryParser: {
+    arrayLimit: 1000,
+    parameterLimit: 1000,
+    depth: 5
+  }
+};
 
 describe('parse-querystring', function () {
   let ctx;
@@ -9,13 +17,14 @@ describe('parse-querystring', function () {
   beforeEach(function () {
     ctx = {
       querystring: 'firstname=john&lastname=doe&children[]=bolek&children[]=lolek',
-      state: {},
+      state: {}
     } as any;
   });
 
   it('parses querystring and calls next', async function () {
     // Prepare
     const next = sandbox.stub();
+    const middleware = parseQuerystring(defaultConfig);
 
     // Execute
     await middleware(ctx, next);
@@ -32,6 +41,7 @@ describe('parse-querystring', function () {
   it('overrides query in state', async function () {
     // Prepare
     const next = sandbox.stub();
+    const middleware = parseQuerystring(defaultConfig);
 
     // Execute
     await middleware(ctx, next);
@@ -40,5 +50,49 @@ describe('parse-querystring', function () {
     next.called.should.be.true();
     ctx.state.query = 'asd';
     ctx.state.query.should.eql('asd');
+  });
+
+  it('keeps bracket arrays (a[]=...) with more than 20 elements as arrays by default', async function () {
+    const next = sandbox.stub();
+    const middleware = parseQuerystring(defaultConfig);
+    const count = 25;
+    ctx.querystring = Array.from({ length: count }, (_, i) => `items[]=${i}`).join('&');
+
+    await middleware(ctx, next);
+
+    next.called.should.be.true();
+    Array.isArray(ctx.state.query.items).should.be.true();
+    ctx.state.query.items.should.have.length(count);
+  });
+
+  it('keeps indexed bracket keys (a[0]=, a[1]=, ...) as arrays when within default arrayLimit', async function () {
+    const next = sandbox.stub();
+    const middleware = parseQuerystring(defaultConfig);
+    const count = 25;
+    ctx.querystring = Array.from({ length: count }, (_, i) => `items[${i}]=${i}`).join('&');
+
+    await middleware(ctx, next);
+
+    next.called.should.be.true();
+    Array.isArray(ctx.state.query.items).should.be.true();
+    ctx.state.query.items.should.have.length(count);
+  });
+
+  it('respects a lower custom arrayLimit for indexed bracket keys', async function () {
+    const next = sandbox.stub();
+    const middleware = parseQuerystring({
+      queryParser: {
+        arrayLimit: 10,
+        parameterLimit: 1000,
+        depth: 5
+      }
+    });
+    const count = 25;
+    ctx.querystring = Array.from({ length: count }, (_, i) => `items[${i}]=${i}`).join('&');
+
+    await middleware(ctx, next);
+
+    next.called.should.be.true();
+    Array.isArray(ctx.state.query.items).should.be.false();
   });
 });


### PR DESCRIPTION
## Summary
This PR restores backward compatibility in Orka query parsing after upgrading qs to the patched versions.

qs >= 6.14.1 now correctly enforces arrayLimit for bracket notation (a[]=1&a[]=2...). With Orka’s previous parser call (qs.parse(ctx.querystring) with defaults), requests with more than 20 bracket-array entries could be parsed as objects instead of arrays, causing downstream validation failures in consuming apps.

This change makes query parsing limits configurable and sets backward-compatible defaults so existing FE/API contracts continue to work.

Related PR https://github.com/Workable/hris/pull/9618
