### PR TITLE
6.0.0-rc.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@workablehr/orka",
-  "version": "5.2.2",
+  "version": "6.0.0-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@workablehr/orka",
-      "version": "5.2.2",
+      "version": "6.0.0-rc.0",
       "license": "ISC",
       "dependencies": {
         "@honeybadger-io/js": "^6.15.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workablehr/orka",
-  "version": "5.2.2",
+  "version": "6.0.0-rc.0",
   "description": "",
   "main": "build/index.js",
   "scripts": {


### PR DESCRIPTION
Version bump for the redis v6 migration prerelease (#503). Will be published to npm under the `beta` dist-tag via `gh:prerelease`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)