### PR TITLE
6.0.0-rc.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@workablehr/orka",
-  "version": "6.0.0-rc.0",
+  "version": "6.0.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@workablehr/orka",
-      "version": "6.0.0-rc.0",
+      "version": "6.0.0-rc.1",
       "license": "ISC",
       "dependencies": {
         "@honeybadger-io/js": "^6.15.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workablehr/orka",
-  "version": "6.0.0-rc.0",
+  "version": "6.0.0-rc.1",
   "description": "",
   "main": "build/index.js",
   "scripts": {


### PR DESCRIPTION
Version bump for the redis v6 migration prerelease (#503).

Replaces the broken `6.0.0-rc.0`: its tag pointed to a pre-merge commit (an `npm version` ran before the migration merge, and the later rebase moved the commit but not the tag), so npm got v5-era code labeled rc.0. That release and tag are deleted; `@workablehr/orka@6.0.0-rc.0` on npm should be deprecated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)