### PR TITLE
bugfix: Pin nanoid to 3.3.18 to fix GHSA-2V37-7H3G-55P8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7360,24 +7360,6 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
     "node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -8555,6 +8537,24 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/postgres-array": {

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "typescript": "^5.2.2"
   },
   "overrides": {
+    "nanoid": "3.3.18",
     "serialize-javascript": "^7.0.5",
     "rabbit-queue": {
       "uuid": "^11.1.1"


### PR DESCRIPTION
## Summary
- Pin transitive `nanoid` dependency to `3.3.18` via npm overrides
- Fixes [GHSA-2V37-7H3G-55P8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) (High): custom generators can loop indefinitely when size is zero
- Dependency chain: `sanitize-html` → `postcss` → `nanoid`

## Jira
[PROD-85777](https://workable.atlassian.net/browse/PROD-85777)

## Test plan
- [x] `npm ls nanoid` shows `nanoid@3.3.18 overridden`
- [ ] CI green

[PROD-85777]: https://workable.atlassian.net/browse/PROD-85777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ